### PR TITLE
CI: increase renovate PR limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,6 @@
     "dependencies"
   ],
   "prConcurrentLimit": 10,
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 10,
   "updateNotScheduled": false
 }


### PR DESCRIPTION
Due to the weekly schedule, renovate currently only creates 2 PR's per week. This PR increases that limit to 10, which is the concurrent PR limit