### PR TITLE
feat: native time/date pickers and keyboard-avoiding layout

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,7 +3,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     PROJECT_NAME: str = "Sophros"
-    VERSION: str = "0.2.0"
+    VERSION: str = "0.2.1"
     API_V1_STR: str = "/api/v1"
 
     # Database

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sophros-backend"
-version = "0.2.0"
+version = "0.2.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -64,6 +64,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   plugins: [
     'expo-router',
+    '@react-native-community/datetimepicker',
     [
       'expo-splash-screen',
       {

--- a/frontend/app/(auth)/sign-in.tsx
+++ b/frontend/app/(auth)/sign-in.tsx
@@ -5,7 +5,7 @@ import { useSignIn } from '@clerk/clerk-expo';
 import type { ClerkAPIResponseError, EmailCodeFactor } from '@clerk/types';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 function isClerkAPIResponseError(err: unknown): err is ClerkAPIResponseError {
@@ -117,103 +117,115 @@ function SignInScreen() {
   if (pendingVerification) {
     return (
       <SafeAreaView style={localStyles.container} edges={['top', 'bottom']}>
-        <ScrollView contentContainerStyle={localStyles.scrollContent}>
-          <View style={styles.formContainer}>
-            <View style={styles.headerContainer}>
-              <Text style={styles.title}>Verify your email</Text>
-              <Text style={styles.subtitle}>
-                Enter the verification code sent to your email address
-              </Text>
-            </View>
-
-            <View style={styles.form}>
-              <View style={styles.inputGroup}>
-                <Text style={styles.label}>Verification code</Text>
-                <TextInput
-                  style={styles.input}
-                  placeholder="Enter the verification code"
-                  placeholderTextColor={Colors.light.textMuted}
-                  value={code}
-                  onChangeText={(text) => setCode(text)}
-                />
+        <KeyboardAvoidingView style={localStyles.keyboardAvoid} behavior="padding">
+          <ScrollView
+            style={localStyles.scrollView}
+            contentContainerStyle={localStyles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.formContainer}>
+              <View style={styles.headerContainer}>
+                <Text style={styles.title}>Verify your email</Text>
+                <Text style={styles.subtitle}>
+                  Enter the verification code sent to your email address
+                </Text>
               </View>
 
-              {error && <Text style={styles.error}>{error}</Text>}
+              <View style={styles.form}>
+                <View style={styles.inputGroup}>
+                  <Text style={styles.label}>Verification code</Text>
+                  <TextInput
+                    style={styles.input}
+                    placeholder="Enter the verification code"
+                    placeholderTextColor={Colors.light.textMuted}
+                    value={code}
+                    onChangeText={(text) => setCode(text)}
+                  />
+                </View>
 
-              <TouchableOpacity style={styles.button} onPress={onVerifyPress} activeOpacity={0.8}>
-                <Text style={styles.buttonText}>Verify</Text>
-              </TouchableOpacity>
+                {error && <Text style={styles.error}>{error}</Text>}
+
+                <TouchableOpacity style={styles.button} onPress={onVerifyPress} activeOpacity={0.8}>
+                  <Text style={styles.buttonText}>Verify</Text>
+                </TouchableOpacity>
+              </View>
             </View>
-          </View>
-        </ScrollView>
+          </ScrollView>
+        </KeyboardAvoidingView>
       </SafeAreaView>
     );
   }
 
   return (
     <SafeAreaView style={localStyles.container} edges={['top', 'bottom']}>
-      <ScrollView contentContainerStyle={localStyles.scrollContent}>
-        <View style={styles.formContainer}>
-          <View style={styles.headerContainer}>
-            <Text style={styles.title}>Sign In</Text>
-            <Text style={styles.subtitle}>Enter your credentials to access your account</Text>
-          </View>
-
-          {/* OAuthButton component to handle OAuth sign-in */}
-          <View style={{ marginBottom: 24 }}>
-            <OAuthButton strategy="oauth_google">Sign in with Google</OAuthButton>
-          </View>
-
-          <View style={styles.form}>
-            <View style={styles.inputGroup}>
-              <Text style={styles.label}>Email address</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="Enter your email address"
-                placeholderTextColor={Colors.light.textMuted}
-                value={emailAddress}
-                onChangeText={(text) => setEmailAddress(text)}
-                autoCapitalize="none"
-                keyboardType="email-address"
-                autoComplete="email"
-              />
+      <KeyboardAvoidingView style={localStyles.keyboardAvoid} behavior="padding">
+        <ScrollView
+          style={localStyles.scrollView}
+          contentContainerStyle={localStyles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.formContainer}>
+            <View style={styles.headerContainer}>
+              <Text style={styles.title}>Sign In</Text>
+              <Text style={styles.subtitle}>Enter your credentials to access your account</Text>
             </View>
 
-            <View style={styles.inputGroup}>
-              <Text style={styles.label}>Password</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="Enter your password"
-                placeholderTextColor={Colors.light.textMuted}
-                value={password}
-                onChangeText={(text) => setPassword(text)}
-                secureTextEntry
-                autoComplete="password"
-              />
+            {/* OAuthButton component to handle OAuth sign-in */}
+            <View style={{ marginBottom: 24 }}>
+              <OAuthButton strategy="oauth_google">Sign in with Google</OAuthButton>
             </View>
 
-            {error && <Text style={styles.error}>{error}</Text>}
+            <View style={styles.form}>
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>Email address</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Enter your email address"
+                  placeholderTextColor={Colors.light.textMuted}
+                  value={emailAddress}
+                  onChangeText={(text) => setEmailAddress(text)}
+                  autoCapitalize="none"
+                  keyboardType="email-address"
+                  autoComplete="email"
+                />
+              </View>
 
-            <TouchableOpacity
-              style={styles.button}
-              onPress={onSignInPress}
-              activeOpacity={0.8}
-              disabled={loading}
-            >
-              <Text style={styles.buttonText}>Sign In</Text>
-            </TouchableOpacity>
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>Password</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Enter your password"
+                  placeholderTextColor={Colors.light.textMuted}
+                  value={password}
+                  onChangeText={(text) => setPassword(text)}
+                  secureTextEntry
+                  autoComplete="password"
+                />
+              </View>
 
-            {/* Link to sign-up screen */}
-            <TouchableOpacity
-              style={styles.textButton}
-              onPress={() => router.push('/sign-up')}
-              activeOpacity={0.8}
-            >
-              <Text style={styles.textButtonText}>Don&apos;t have an account? Sign up.</Text>
-            </TouchableOpacity>
+              {error && <Text style={styles.error}>{error}</Text>}
+
+              <TouchableOpacity
+                style={styles.button}
+                onPress={onSignInPress}
+                activeOpacity={0.8}
+                disabled={loading}
+              >
+                <Text style={styles.buttonText}>Sign In</Text>
+              </TouchableOpacity>
+
+              {/* Link to sign-up screen */}
+              <TouchableOpacity
+                style={styles.textButton}
+                onPress={() => router.push('/sign-up')}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.textButtonText}>Don&apos;t have an account? Sign up.</Text>
+              </TouchableOpacity>
+            </View>
           </View>
-        </View>
-      </ScrollView>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
@@ -222,6 +234,12 @@ const localStyles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.light.background,
+  },
+  keyboardAvoid: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
   },
   scrollContent: {
     flexGrow: 1,

--- a/frontend/app/(auth)/sign-in.tsx
+++ b/frontend/app/(auth)/sign-in.tsx
@@ -5,7 +5,15 @@ import { useSignIn } from '@clerk/clerk-expo';
 import type { ClerkAPIResponseError, EmailCodeFactor } from '@clerk/types';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { KeyboardAvoidingView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 function isClerkAPIResponseError(err: unknown): err is ClerkAPIResponseError {

--- a/frontend/app/(auth)/sign-up.tsx
+++ b/frontend/app/(auth)/sign-up.tsx
@@ -5,7 +5,15 @@ import { useSignUp } from '@clerk/clerk-expo';
 import type { ClerkAPIResponseError } from '@clerk/types';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { KeyboardAvoidingView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import {
+  KeyboardAvoidingView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 function SignUpScreen() {

--- a/frontend/app/(auth)/sign-up.tsx
+++ b/frontend/app/(auth)/sign-up.tsx
@@ -5,7 +5,7 @@ import { useSignUp } from '@clerk/clerk-expo';
 import type { ClerkAPIResponseError } from '@clerk/types';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { KeyboardAvoidingView, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 function SignUpScreen() {
@@ -99,40 +99,46 @@ function SignUpScreen() {
   if (pendingVerification) {
     return (
       <SafeAreaView style={localStyles.container} edges={['top', 'bottom']}>
-        <ScrollView contentContainerStyle={localStyles.scrollContent}>
-          <View style={styles.formContainer}>
-            <View style={styles.headerContainer}>
-              <Text style={styles.title}>Verify your email</Text>
-              <Text style={styles.subtitle}>
-                Enter the verification code sent to your email address
-              </Text>
-            </View>
-
-            <View style={styles.form}>
-              <View style={styles.inputGroup}>
-                <Text style={styles.label}>Verification code</Text>
-                <TextInput
-                  style={styles.input}
-                  placeholder="Enter the verification code"
-                  placeholderTextColor={Colors.light.textMuted}
-                  value={code}
-                  onChangeText={(text) => setCode(text)}
-                />
+        <KeyboardAvoidingView style={localStyles.keyboardAvoid} behavior="padding">
+          <ScrollView
+            style={localStyles.scrollView}
+            contentContainerStyle={localStyles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.formContainer}>
+              <View style={styles.headerContainer}>
+                <Text style={styles.title}>Verify your email</Text>
+                <Text style={styles.subtitle}>
+                  Enter the verification code sent to your email address
+                </Text>
               </View>
 
-              {error && <Text style={styles.error}>{error}</Text>}
+              <View style={styles.form}>
+                <View style={styles.inputGroup}>
+                  <Text style={styles.label}>Verification code</Text>
+                  <TextInput
+                    style={styles.input}
+                    placeholder="Enter the verification code"
+                    placeholderTextColor={Colors.light.textMuted}
+                    value={code}
+                    onChangeText={(text) => setCode(text)}
+                  />
+                </View>
 
-              <TouchableOpacity
-                style={styles.button}
-                onPress={onVerifyPress}
-                activeOpacity={0.8}
-                disabled={loading}
-              >
-                <Text style={styles.buttonText}>Verify</Text>
-              </TouchableOpacity>
+                {error && <Text style={styles.error}>{error}</Text>}
+
+                <TouchableOpacity
+                  style={styles.button}
+                  onPress={onVerifyPress}
+                  activeOpacity={0.8}
+                  disabled={loading}
+                >
+                  <Text style={styles.buttonText}>Verify</Text>
+                </TouchableOpacity>
+              </View>
             </View>
-          </View>
-        </ScrollView>
+          </ScrollView>
+        </KeyboardAvoidingView>
       </SafeAreaView>
     );
   }
@@ -140,89 +146,95 @@ function SignUpScreen() {
   // Sign up screen
   return (
     <SafeAreaView style={localStyles.container} edges={['top', 'bottom']}>
-      <ScrollView contentContainerStyle={localStyles.scrollContent}>
-        <View style={styles.formContainer}>
-          <View style={styles.headerContainer}>
-            <Text style={styles.title}>Sign Up</Text>
-            <Text style={styles.subtitle}>Create your account to get started</Text>
+      <KeyboardAvoidingView style={localStyles.keyboardAvoid} behavior="padding">
+        <ScrollView
+          style={localStyles.scrollView}
+          contentContainerStyle={localStyles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.formContainer}>
+            <View style={styles.headerContainer}>
+              <Text style={styles.title}>Sign Up</Text>
+              <Text style={styles.subtitle}>Create your account to get started</Text>
+            </View>
+
+            {/* OAuthButton component can also be used to create accounts */}
+            <View style={{ marginBottom: 24 }}>
+              <OAuthButton strategy="oauth_google">Sign in with Google</OAuthButton>
+            </View>
+
+            <View style={styles.form}>
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>First name</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Enter your first name"
+                  placeholderTextColor={Colors.light.textMuted}
+                  value={firstName}
+                  onChangeText={(text) => setFirstName(text)}
+                  autoCapitalize="words"
+                />
+              </View>
+
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>Last name</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Enter your last name"
+                  placeholderTextColor={Colors.light.textMuted}
+                  value={lastName}
+                  onChangeText={(text) => setLastName(text)}
+                  autoCapitalize="words"
+                />
+              </View>
+
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>Email address</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Enter your email address"
+                  placeholderTextColor={Colors.light.textMuted}
+                  value={emailAddress}
+                  onChangeText={(text) => setEmailAddress(text)}
+                  autoCapitalize="none"
+                  keyboardType="email-address"
+                />
+              </View>
+
+              <View style={styles.inputGroup}>
+                <Text style={styles.label}>Password</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Create a password"
+                  placeholderTextColor={Colors.light.textMuted}
+                  value={password}
+                  onChangeText={(text) => setPassword(text)}
+                  secureTextEntry
+                />
+              </View>
+
+              {error && <Text style={styles.error}>{error}</Text>}
+
+              <TouchableOpacity
+                style={styles.button}
+                onPress={onSignUpPress}
+                activeOpacity={0.8}
+                disabled={loading}
+              >
+                <Text style={styles.buttonText}>Sign Up</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.textButton}
+                onPress={() => router.push('/sign-in')}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.textButtonText}>Already have an account? Sign in.</Text>
+              </TouchableOpacity>
+            </View>
           </View>
-
-          {/* OAuthButton component can also be used to create accounts */}
-          <View style={{ marginBottom: 24 }}>
-            <OAuthButton strategy="oauth_google">Sign in with Google</OAuthButton>
-          </View>
-
-          <View style={styles.form}>
-            <View style={styles.inputGroup}>
-              <Text style={styles.label}>First name</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="Enter your first name"
-                placeholderTextColor={Colors.light.textMuted}
-                value={firstName}
-                onChangeText={(text) => setFirstName(text)}
-                autoCapitalize="words"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <Text style={styles.label}>Last name</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="Enter your last name"
-                placeholderTextColor={Colors.light.textMuted}
-                value={lastName}
-                onChangeText={(text) => setLastName(text)}
-                autoCapitalize="words"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <Text style={styles.label}>Email address</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="Enter your email address"
-                placeholderTextColor={Colors.light.textMuted}
-                value={emailAddress}
-                onChangeText={(text) => setEmailAddress(text)}
-                autoCapitalize="none"
-                keyboardType="email-address"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <Text style={styles.label}>Password</Text>
-              <TextInput
-                style={styles.input}
-                placeholder="Create a password"
-                placeholderTextColor={Colors.light.textMuted}
-                value={password}
-                onChangeText={(text) => setPassword(text)}
-                secureTextEntry
-              />
-            </View>
-
-            {error && <Text style={styles.error}>{error}</Text>}
-
-            <TouchableOpacity
-              style={styles.button}
-              onPress={onSignUpPress}
-              activeOpacity={0.8}
-              disabled={loading}
-            >
-              <Text style={styles.buttonText}>Sign Up</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.textButton}
-              onPress={() => router.push('/sign-in')}
-              activeOpacity={0.8}
-            >
-              <Text style={styles.textButtonText}>Already have an account? Sign in.</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </ScrollView>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
@@ -231,6 +243,12 @@ const localStyles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.light.background,
+  },
+  keyboardAvoid: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
   },
   scrollContent: {
     flexGrow: 1,

--- a/frontend/app/onboarding/step1.tsx
+++ b/frontend/app/onboarding/step1.tsx
@@ -7,7 +7,6 @@ import { router } from 'expo-router';
 import React from 'react';
 import {
   KeyboardAvoidingView,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -25,11 +24,13 @@ export default function Step1Screen() {
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior="padding"
       >
         <ScrollView
+          style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
         >
           <View style={styles.progressContainer}>
             <View style={styles.progressBar}>
@@ -95,9 +96,12 @@ const styles = StyleSheet.create({
   keyboardAvoid: {
     flex: 1,
   },
+  scrollView: {
+    flex: 1,
+  },
   scrollContent: {
     padding: 20,
-    paddingBottom: 100,
+    paddingBottom: 20,
   },
   progressContainer: {
     marginBottom: 24,
@@ -152,10 +156,6 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   buttonContainer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
     padding: 20,
     paddingBottom: 30,
     backgroundColor: Colors.light.background,

--- a/frontend/app/onboarding/step1.tsx
+++ b/frontend/app/onboarding/step1.tsx
@@ -22,10 +22,7 @@ export default function Step1Screen() {
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoid}
-        behavior="padding"
-      >
+      <KeyboardAvoidingView style={styles.keyboardAvoid} behavior="padding">
         <ScrollView
           style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}

--- a/frontend/app/onboarding/step2.tsx
+++ b/frontend/app/onboarding/step2.tsx
@@ -6,7 +6,6 @@ import { router } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import {
   KeyboardAvoidingView,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -109,11 +108,13 @@ export default function Step2Screen() {
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior="padding"
       >
         <ScrollView
+          style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
         >
           <View style={styles.progressContainer}>
             <View style={styles.progressBar}>
@@ -246,9 +247,12 @@ const styles = StyleSheet.create({
   keyboardAvoid: {
     flex: 1,
   },
+  scrollView: {
+    flex: 1,
+  },
   scrollContent: {
     padding: 20,
-    paddingBottom: 100,
+    paddingBottom: 20,
   },
   progressContainer: {
     marginBottom: 24,
@@ -329,10 +333,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   buttonContainer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
     padding: 20,
     paddingBottom: 30,
     backgroundColor: Colors.light.background,

--- a/frontend/app/onboarding/step2.tsx
+++ b/frontend/app/onboarding/step2.tsx
@@ -106,10 +106,7 @@ export default function Step2Screen() {
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoid}
-        behavior="padding"
-      >
+      <KeyboardAvoidingView style={styles.keyboardAvoid} behavior="padding">
         <ScrollView
           style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}

--- a/frontend/app/onboarding/step5.tsx
+++ b/frontend/app/onboarding/step5.tsx
@@ -54,10 +54,7 @@ export default function Step5Screen() {
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
-      <KeyboardAvoidingView
-        style={styles.keyboardAvoid}
-        behavior="padding"
-      >
+      <KeyboardAvoidingView style={styles.keyboardAvoid} behavior="padding">
         <ScrollView
           style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}

--- a/frontend/app/onboarding/step5.tsx
+++ b/frontend/app/onboarding/step5.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
@@ -57,11 +56,13 @@ export default function Step5Screen() {
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior="padding"
       >
         <ScrollView
+          style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
         >
           <View style={styles.progressContainer}>
             <View style={styles.progressBar}>
@@ -138,9 +139,12 @@ const styles = StyleSheet.create({
   keyboardAvoid: {
     flex: 1,
   },
+  scrollView: {
+    flex: 1,
+  },
   scrollContent: {
     padding: 20,
-    paddingBottom: 100,
+    paddingBottom: 20,
   },
   progressContainer: {
     marginBottom: 24,
@@ -197,10 +201,6 @@ const styles = StyleSheet.create({
     color: Colors.light.text,
   },
   buttonContainer: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    right: 0,
     padding: 20,
     paddingBottom: 30,
     backgroundColor: Colors.light.background,

--- a/frontend/app/onboarding/step5.tsx
+++ b/frontend/app/onboarding/step5.tsx
@@ -1,4 +1,5 @@
 import { MetricInput } from '@/components/MetricInput';
+import { TimePickerInput } from '@/components/TimePickerInput';
 import { Colors, Shadows } from '@/constants/theme';
 import { useOnboarding } from '@/hooks/useOnboarding';
 import { kgToLbs, lbsToKg } from '@/utils/units';
@@ -11,7 +12,6 @@ import {
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -88,27 +88,17 @@ export default function Step5Screen() {
               />
             </View>
 
-            <View style={styles.fieldContainer}>
-              <Text style={styles.fieldLabel}>Wake Up Time</Text>
-              <TextInput
-                style={styles.input}
-                value={data.wakeUpTime}
-                onChangeText={(value) => updateField('wakeUpTime', value)}
-                placeholder="07:00"
-                placeholderTextColor={Colors.light.textMuted}
-              />
-            </View>
+            <TimePickerInput
+              label="Wake Up Time"
+              value={data.wakeUpTime}
+              onChange={(v) => updateField('wakeUpTime', v)}
+            />
 
-            <View style={styles.fieldContainer}>
-              <Text style={styles.fieldLabel}>Sleep Time</Text>
-              <TextInput
-                style={styles.input}
-                value={data.sleepTime}
-                onChangeText={(value) => updateField('sleepTime', value)}
-                placeholder="23:00"
-                placeholderTextColor={Colors.light.textMuted}
-              />
-            </View>
+            <TimePickerInput
+              label="Sleep Time"
+              value={data.sleepTime}
+              onChange={(v) => updateField('sleepTime', v)}
+            />
           </View>
         </ScrollView>
 
@@ -181,24 +171,6 @@ const styles = StyleSheet.create({
   },
   content: {
     gap: 24,
-  },
-  fieldContainer: {
-    gap: 8,
-  },
-  fieldLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: Colors.light.text,
-  },
-  input: {
-    backgroundColor: Colors.light.surface,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-    fontSize: 16,
-    color: Colors.light.text,
   },
   buttonContainer: {
     padding: 20,

--- a/frontend/app/profile/edit.tsx
+++ b/frontend/app/profile/edit.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import {
   ActivityIndicator,
   Alert,
+  KeyboardAvoidingView,
   ScrollView,
   StyleSheet,
   Text,
@@ -465,19 +466,25 @@ export default function EditProfileScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-      <View style={styles.header}>
-        <TouchableOpacity
-          style={styles.backButton}
-          onPress={() => router.back()}
-          activeOpacity={0.8}
-        >
-          <ArrowLeft size={20} color={Colors.light.text} />
-        </TouchableOpacity>
-        <Text style={styles.headerTitle}>Edit Profile</Text>
-        <View style={styles.headerSpacer} />
-      </View>
+      <KeyboardAvoidingView style={styles.keyboardAvoid} behavior="padding">
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={styles.backButton}
+            onPress={() => router.back()}
+            activeOpacity={0.8}
+          >
+            <ArrowLeft size={20} color={Colors.light.text} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Edit Profile</Text>
+          <View style={styles.headerSpacer} />
+        </View>
 
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
         <View style={styles.sectionCard}>
           <Text style={styles.sectionTitle}>Basics</Text>
 
@@ -729,6 +736,7 @@ export default function EditProfileScreen() {
           )}
         </TouchableOpacity>
       </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
@@ -772,6 +780,12 @@ const styles = StyleSheet.create({
   headerSpacer: {
     width: 40,
     height: 40,
+  },
+  keyboardAvoid: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
   },
   scrollContent: {
     paddingHorizontal: 20,

--- a/frontend/app/profile/edit.tsx
+++ b/frontend/app/profile/edit.tsx
@@ -487,240 +487,240 @@ export default function EditProfileScreen() {
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
-        <View style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>Basics</Text>
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Basics</Text>
 
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Age</Text>
-            <TextInput
-              style={styles.input}
-              value={form.age}
-              onChangeText={(text) => updateForm('age', text)}
-              keyboardType="number-pad"
-              placeholder="Enter age"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
-
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Unit Preference</Text>
-            <View style={styles.segmentedControl}>
-              <TouchableOpacity
-                style={[styles.segmentButton, !form.showImperial && styles.segmentButtonActive]}
-                onPress={() => handleUnitPreferenceChange(false)}
-                activeOpacity={0.8}
-              >
-                <Text
-                  style={[
-                    styles.segmentButtonText,
-                    !form.showImperial && styles.segmentButtonTextActive,
-                  ]}
-                >
-                  Metric
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.segmentButton, form.showImperial && styles.segmentButtonActive]}
-                onPress={() => handleUnitPreferenceChange(true)}
-                activeOpacity={0.8}
-              >
-                <Text
-                  style={[
-                    styles.segmentButtonText,
-                    form.showImperial && styles.segmentButtonTextActive,
-                  ]}
-                >
-                  Imperial
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </View>
-
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Weight ({form.showImperial ? 'lbs' : 'kg'})</Text>
-            <TextInput
-              style={styles.input}
-              value={form.weight}
-              onChangeText={(text) => updateForm('weight', text)}
-              keyboardType="decimal-pad"
-              placeholder={form.showImperial ? 'Enter weight in lbs' : 'Enter weight in kg'}
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
-
-          {form.showImperial ? (
             <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Height</Text>
-              <View style={styles.imperialHeightRow}>
-                <TextInput
-                  style={[styles.input, styles.imperialInput]}
-                  value={form.heightFeet}
-                  onChangeText={(text) => updateForm('heightFeet', text)}
-                  keyboardType="decimal-pad"
-                  placeholder="ft"
-                  placeholderTextColor={Colors.light.textMuted}
-                />
-                <TextInput
-                  style={[styles.input, styles.imperialInput]}
-                  value={form.heightInches}
-                  onChangeText={(text) => updateForm('heightInches', text)}
-                  keyboardType="decimal-pad"
-                  placeholder="in"
-                  placeholderTextColor={Colors.light.textMuted}
-                />
-              </View>
-            </View>
-          ) : (
-            <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Height (cm)</Text>
+              <Text style={styles.inputLabel}>Age</Text>
               <TextInput
                 style={styles.input}
-                value={form.heightCm}
-                onChangeText={(text) => updateForm('heightCm', text)}
-                keyboardType="decimal-pad"
-                placeholder="Enter height in cm"
+                value={form.age}
+                onChangeText={(text) => updateForm('age', text)}
+                keyboardType="number-pad"
+                placeholder="Enter age"
                 placeholderTextColor={Colors.light.textMuted}
               />
             </View>
-          )}
-        </View>
 
-        <View style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>Activity Level</Text>
-          <View style={styles.activityList}>
-            {ACTIVITY_LEVEL_OPTIONS.map((option) => (
-              <SelectionCard
-                key={option.value}
-                title={option.label}
-                description={option.description}
-                selected={form.activityLevel === option.value}
-                onPress={() => updateForm('activityLevel', option.value)}
-              />
-            ))}
-          </View>
-        </View>
-
-        <View style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>Goals</Text>
-
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>
-              Target Weight ({form.showImperial ? 'lbs' : 'kg'})
-            </Text>
-            <TextInput
-              style={styles.input}
-              value={form.targetWeight}
-              onChangeText={(text) => updateForm('targetWeight', text)}
-              keyboardType="decimal-pad"
-              placeholder="Optional"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
-
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Target Body Fat %</Text>
-            <TextInput
-              style={styles.input}
-              value={form.targetBodyFat}
-              onChangeText={(text) => updateForm('targetBodyFat', text)}
-              keyboardType="decimal-pad"
-              placeholder="Optional"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
-
-          <DatePickerInput
-            label="Target Date"
-            value={form.targetDate}
-            onChange={(v) => updateForm('targetDate', v)}
-          />
-        </View>
-
-        <View style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>Schedule</Text>
-
-          <TimePickerInput
-            label="Wake Up Time"
-            value={form.wakeUpTime}
-            onChange={(v) => updateForm('wakeUpTime', v)}
-          />
-
-          <TimePickerInput
-            label="Sleep Time"
-            value={form.sleepTime}
-            onChange={(v) => updateForm('sleepTime', v)}
-          />
-
-          <View style={styles.busyTimesHeader}>
-            <Text style={styles.inputLabel}>Busy Times</Text>
-            <TouchableOpacity onPress={addBusyTime} activeOpacity={0.8}>
-              <Text style={styles.addButtonText}>+ Add</Text>
-            </TouchableOpacity>
-          </View>
-
-          {form.busyTimes.length === 0 ? (
-            <Text style={styles.emptyStateText}>
-              No busy times set. Add recurring weekly blocks to optimize meal scheduling.
-            </Text>
-          ) : (
-            form.busyTimes.map((bt, index) => (
-              <View key={index} style={styles.busyTimeBlock}>
-                <View style={styles.dayChipsRow}>
-                  {DAYS.map((day, dayIndex) => (
-                    <TouchableOpacity
-                      key={day}
-                      style={[styles.dayChip, bt.day === day && styles.dayChipActive]}
-                      onPress={() => updateBusyTime(index, 'day', day)}
-                      activeOpacity={0.8}
-                    >
-                      <Text
-                        style={[styles.dayChipText, bt.day === day && styles.dayChipTextActive]}
-                      >
-                        {DAY_LABELS[dayIndex]}
-                      </Text>
-                    </TouchableOpacity>
-                  ))}
-                </View>
-                <View style={styles.busyTimeRow}>
-                  <TimePickerInput
-                    label="Start"
-                    value={bt.start}
-                    onChange={(text) => updateBusyTime(index, 'start', text)}
-                    style={styles.imperialInput}
-                  />
-                  <Text style={styles.timeSeparator}>to</Text>
-                  <TimePickerInput
-                    label="End"
-                    value={bt.end}
-                    onChange={(text) => updateBusyTime(index, 'end', text)}
-                    style={styles.imperialInput}
-                  />
-                  <TouchableOpacity
-                    style={styles.removeButton}
-                    onPress={() => removeBusyTime(index)}
-                    activeOpacity={0.8}
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>Unit Preference</Text>
+              <View style={styles.segmentedControl}>
+                <TouchableOpacity
+                  style={[styles.segmentButton, !form.showImperial && styles.segmentButtonActive]}
+                  onPress={() => handleUnitPreferenceChange(false)}
+                  activeOpacity={0.8}
+                >
+                  <Text
+                    style={[
+                      styles.segmentButtonText,
+                      !form.showImperial && styles.segmentButtonTextActive,
+                    ]}
                   >
-                    <Text style={styles.removeButtonText}>Remove</Text>
-                  </TouchableOpacity>
+                    Metric
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.segmentButton, form.showImperial && styles.segmentButtonActive]}
+                  onPress={() => handleUnitPreferenceChange(true)}
+                  activeOpacity={0.8}
+                >
+                  <Text
+                    style={[
+                      styles.segmentButtonText,
+                      form.showImperial && styles.segmentButtonTextActive,
+                    ]}
+                  >
+                    Imperial
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>Weight ({form.showImperial ? 'lbs' : 'kg'})</Text>
+              <TextInput
+                style={styles.input}
+                value={form.weight}
+                onChangeText={(text) => updateForm('weight', text)}
+                keyboardType="decimal-pad"
+                placeholder={form.showImperial ? 'Enter weight in lbs' : 'Enter weight in kg'}
+                placeholderTextColor={Colors.light.textMuted}
+              />
+            </View>
+
+            {form.showImperial ? (
+              <View style={styles.inputGroup}>
+                <Text style={styles.inputLabel}>Height</Text>
+                <View style={styles.imperialHeightRow}>
+                  <TextInput
+                    style={[styles.input, styles.imperialInput]}
+                    value={form.heightFeet}
+                    onChangeText={(text) => updateForm('heightFeet', text)}
+                    keyboardType="decimal-pad"
+                    placeholder="ft"
+                    placeholderTextColor={Colors.light.textMuted}
+                  />
+                  <TextInput
+                    style={[styles.input, styles.imperialInput]}
+                    value={form.heightInches}
+                    onChangeText={(text) => updateForm('heightInches', text)}
+                    keyboardType="decimal-pad"
+                    placeholder="in"
+                    placeholderTextColor={Colors.light.textMuted}
+                  />
                 </View>
               </View>
-            ))
-          )}
-        </View>
+            ) : (
+              <View style={styles.inputGroup}>
+                <Text style={styles.inputLabel}>Height (cm)</Text>
+                <TextInput
+                  style={styles.input}
+                  value={form.heightCm}
+                  onChangeText={(text) => updateForm('heightCm', text)}
+                  keyboardType="decimal-pad"
+                  placeholder="Enter height in cm"
+                  placeholderTextColor={Colors.light.textMuted}
+                />
+              </View>
+            )}
+          </View>
 
-        <TouchableOpacity
-          style={[styles.saveButton, saving && styles.saveButtonDisabled]}
-          onPress={handleSave}
-          disabled={saving}
-          activeOpacity={0.8}
-        >
-          {saving ? (
-            <ActivityIndicator color={Colors.light.surface} size="small" />
-          ) : (
-            <Text style={styles.saveButtonText}>Save Changes</Text>
-          )}
-        </TouchableOpacity>
-      </ScrollView>
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Activity Level</Text>
+            <View style={styles.activityList}>
+              {ACTIVITY_LEVEL_OPTIONS.map((option) => (
+                <SelectionCard
+                  key={option.value}
+                  title={option.label}
+                  description={option.description}
+                  selected={form.activityLevel === option.value}
+                  onPress={() => updateForm('activityLevel', option.value)}
+                />
+              ))}
+            </View>
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Goals</Text>
+
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>
+                Target Weight ({form.showImperial ? 'lbs' : 'kg'})
+              </Text>
+              <TextInput
+                style={styles.input}
+                value={form.targetWeight}
+                onChangeText={(text) => updateForm('targetWeight', text)}
+                keyboardType="decimal-pad"
+                placeholder="Optional"
+                placeholderTextColor={Colors.light.textMuted}
+              />
+            </View>
+
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>Target Body Fat %</Text>
+              <TextInput
+                style={styles.input}
+                value={form.targetBodyFat}
+                onChangeText={(text) => updateForm('targetBodyFat', text)}
+                keyboardType="decimal-pad"
+                placeholder="Optional"
+                placeholderTextColor={Colors.light.textMuted}
+              />
+            </View>
+
+            <DatePickerInput
+              label="Target Date"
+              value={form.targetDate}
+              onChange={(v) => updateForm('targetDate', v)}
+            />
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Schedule</Text>
+
+            <TimePickerInput
+              label="Wake Up Time"
+              value={form.wakeUpTime}
+              onChange={(v) => updateForm('wakeUpTime', v)}
+            />
+
+            <TimePickerInput
+              label="Sleep Time"
+              value={form.sleepTime}
+              onChange={(v) => updateForm('sleepTime', v)}
+            />
+
+            <View style={styles.busyTimesHeader}>
+              <Text style={styles.inputLabel}>Busy Times</Text>
+              <TouchableOpacity onPress={addBusyTime} activeOpacity={0.8}>
+                <Text style={styles.addButtonText}>+ Add</Text>
+              </TouchableOpacity>
+            </View>
+
+            {form.busyTimes.length === 0 ? (
+              <Text style={styles.emptyStateText}>
+                No busy times set. Add recurring weekly blocks to optimize meal scheduling.
+              </Text>
+            ) : (
+              form.busyTimes.map((bt, index) => (
+                <View key={index} style={styles.busyTimeBlock}>
+                  <View style={styles.dayChipsRow}>
+                    {DAYS.map((day, dayIndex) => (
+                      <TouchableOpacity
+                        key={day}
+                        style={[styles.dayChip, bt.day === day && styles.dayChipActive]}
+                        onPress={() => updateBusyTime(index, 'day', day)}
+                        activeOpacity={0.8}
+                      >
+                        <Text
+                          style={[styles.dayChipText, bt.day === day && styles.dayChipTextActive]}
+                        >
+                          {DAY_LABELS[dayIndex]}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                  <View style={styles.busyTimeRow}>
+                    <TimePickerInput
+                      label="Start"
+                      value={bt.start}
+                      onChange={(text) => updateBusyTime(index, 'start', text)}
+                      style={styles.imperialInput}
+                    />
+                    <Text style={styles.timeSeparator}>to</Text>
+                    <TimePickerInput
+                      label="End"
+                      value={bt.end}
+                      onChange={(text) => updateBusyTime(index, 'end', text)}
+                      style={styles.imperialInput}
+                    />
+                    <TouchableOpacity
+                      style={styles.removeButton}
+                      onPress={() => removeBusyTime(index)}
+                      activeOpacity={0.8}
+                    >
+                      <Text style={styles.removeButtonText}>Remove</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ))
+            )}
+          </View>
+
+          <TouchableOpacity
+            style={[styles.saveButton, saving && styles.saveButtonDisabled]}
+            onPress={handleSave}
+            disabled={saving}
+            activeOpacity={0.8}
+          >
+            {saving ? (
+              <ActivityIndicator color={Colors.light.surface} size="small" />
+            ) : (
+              <Text style={styles.saveButtonText}>Save Changes</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );

--- a/frontend/app/profile/edit.tsx
+++ b/frontend/app/profile/edit.tsx
@@ -1,5 +1,7 @@
 import type { ActivityLevel, BusyTime, Day, UserUpdate } from '@/api/types.gen';
+import { DatePickerInput } from '@/components/DatePickerInput';
 import { SelectionCard } from '@/components/SelectionCard';
+import { TimePickerInput } from '@/components/TimePickerInput';
 import { ACTIVITY_LEVEL_OPTIONS, VALIDATION_RULES } from '@/constants/onboarding';
 import { Colors, Layout, Shadows } from '@/constants/theme';
 import { useUserProfile } from '@/hooks/useUserProfile';
@@ -627,42 +629,27 @@ export default function EditProfileScreen() {
             />
           </View>
 
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Target Date</Text>
-            <TextInput
-              style={styles.input}
-              value={form.targetDate}
-              onChangeText={(text) => updateForm('targetDate', text)}
-              placeholder="YYYY-MM-DD"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
+          <DatePickerInput
+            label="Target Date"
+            value={form.targetDate}
+            onChange={(v) => updateForm('targetDate', v)}
+          />
         </View>
 
         <View style={styles.sectionCard}>
           <Text style={styles.sectionTitle}>Schedule</Text>
 
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Wake Up Time</Text>
-            <TextInput
-              style={styles.input}
-              value={form.wakeUpTime}
-              onChangeText={(text) => updateForm('wakeUpTime', text)}
-              placeholder="07:00"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
+          <TimePickerInput
+            label="Wake Up Time"
+            value={form.wakeUpTime}
+            onChange={(v) => updateForm('wakeUpTime', v)}
+          />
 
-          <View style={styles.inputGroup}>
-            <Text style={styles.inputLabel}>Sleep Time</Text>
-            <TextInput
-              style={styles.input}
-              value={form.sleepTime}
-              onChangeText={(text) => updateForm('sleepTime', text)}
-              placeholder="23:00"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
+          <TimePickerInput
+            label="Sleep Time"
+            value={form.sleepTime}
+            onChange={(v) => updateForm('sleepTime', v)}
+          />
 
           <View style={styles.busyTimesHeader}>
             <Text style={styles.inputLabel}>Busy Times</Text>
@@ -695,20 +682,18 @@ export default function EditProfileScreen() {
                   ))}
                 </View>
                 <View style={styles.busyTimeRow}>
-                  <TextInput
-                    style={[styles.input, styles.timeInput]}
+                  <TimePickerInput
+                    label="Start"
                     value={bt.start}
-                    onChangeText={(text) => updateBusyTime(index, 'start', text)}
-                    placeholder="09:00"
-                    placeholderTextColor={Colors.light.textMuted}
+                    onChange={(text) => updateBusyTime(index, 'start', text)}
+                    style={styles.imperialInput}
                   />
                   <Text style={styles.timeSeparator}>to</Text>
-                  <TextInput
-                    style={[styles.input, styles.timeInput]}
+                  <TimePickerInput
+                    label="End"
                     value={bt.end}
-                    onChangeText={(text) => updateBusyTime(index, 'end', text)}
-                    placeholder="17:00"
-                    placeholderTextColor={Colors.light.textMuted}
+                    onChange={(text) => updateBusyTime(index, 'end', text)}
+                    style={styles.imperialInput}
                   />
                   <TouchableOpacity
                     style={styles.removeButton}
@@ -907,7 +892,7 @@ const styles = StyleSheet.create({
   },
   busyTimeRow: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     gap: 8,
   },
   timeInput: {
@@ -916,6 +901,7 @@ const styles = StyleSheet.create({
   timeSeparator: {
     color: Colors.light.textMuted,
     fontSize: 14,
+    paddingBottom: 12,
   },
   removeButton: {
     paddingHorizontal: 8,

--- a/frontend/components/DatePickerInput.tsx
+++ b/frontend/components/DatePickerInput.tsx
@@ -1,0 +1,188 @@
+import { Colors } from '@/constants/theme';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import React, { useState } from 'react';
+import {
+  Modal,
+  Platform,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+interface DatePickerInputProps {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+function parseValue(value: string): Date {
+  if (!value) return new Date();
+  const d = new Date(value + 'T00:00:00');
+  return isNaN(d.getTime()) ? new Date() : d;
+}
+
+function formatOutput(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function displayDate(value: string): string {
+  if (!value) return 'Select a date';
+  const d = new Date(value + 'T00:00:00');
+  if (isNaN(d.getTime())) return 'Select a date';
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export function DatePickerInput({ label, value, onChange, style }: DatePickerInputProps) {
+  const currentDate = parseValue(value);
+  const [showPicker, setShowPicker] = useState(false);
+  const [tempDate, setTempDate] = useState(currentDate);
+
+  const open = () => {
+    setTempDate(parseValue(value));
+    setShowPicker(true);
+  };
+
+  const confirm = () => {
+    setShowPicker(false);
+    onChange(formatOutput(tempDate));
+  };
+
+  const cancel = () => {
+    setShowPicker(false);
+  };
+
+  const clear = () => {
+    onChange('');
+  };
+
+  return (
+    <View style={style}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.row}>
+        <TouchableOpacity style={styles.input} onPress={open} activeOpacity={0.7}>
+          <Text style={value ? styles.inputText : styles.inputPlaceholder}>
+            {displayDate(value)}
+          </Text>
+        </TouchableOpacity>
+        {value ? (
+          <TouchableOpacity style={styles.clearButton} onPress={clear} activeOpacity={0.7}>
+            <Text style={styles.clearButtonText}>×</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
+      {Platform.OS === 'ios' && showPicker && (
+        <Modal transparent animationType="slide">
+          <View style={styles.modalOverlay}>
+            <View style={styles.pickerContainer}>
+              <View style={styles.pickerHeader}>
+                <TouchableOpacity onPress={cancel}>
+                  <Text style={styles.pickerHeaderCancel}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={confirm}>
+                  <Text style={styles.pickerHeaderDone}>Done</Text>
+                </TouchableOpacity>
+              </View>
+              <DateTimePicker
+                value={tempDate}
+                mode="date"
+                display="spinner"
+                onChange={(_, date) => setTempDate(date ?? tempDate)}
+              />
+            </View>
+          </View>
+        </Modal>
+      )}
+
+      {Platform.OS === 'android' && showPicker && (
+        <DateTimePicker
+          value={currentDate}
+          mode="date"
+          display="default"
+          onChange={(_, date) => {
+            setShowPicker(false);
+            if (date) onChange(formatOutput(date));
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.light.text,
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: Colors.light.background,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  inputText: {
+    fontSize: 16,
+    color: Colors.light.text,
+  },
+  inputPlaceholder: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+  },
+  clearButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: Colors.light.surface,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  clearButtonText: {
+    fontSize: 18,
+    color: Colors.light.textMuted,
+    lineHeight: 22,
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  pickerContainer: {
+    backgroundColor: Colors.light.surface,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingBottom: 30,
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  pickerHeaderCancel: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+  },
+  pickerHeaderDone: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.primary,
+  },
+});

--- a/frontend/components/EditItemModal.tsx
+++ b/frontend/components/EditItemModal.tsx
@@ -1,5 +1,6 @@
 import { Colors } from '@/constants/theme';
 import type { ItemType, WeeklyScheduleItem } from '@/types/schedule';
+import { TimePickerInput } from '@/components/TimePickerInput';
 import { X } from 'lucide-react-native';
 import React, { useState } from 'react';
 import {
@@ -114,13 +115,11 @@ export function EditItemModal({
           {/* Form */}
           <ScrollView style={styles.form}>
             <View style={styles.field}>
-              <Text style={styles.label}>Time</Text>
-              <TextInput
-                style={styles.input}
+              <TimePickerInput
+                label="Time"
                 value={time}
-                onChangeText={setTime}
-                placeholder="e.g., 7:00 AM"
-                placeholderTextColor={Colors.light.textMuted}
+                onChange={setTime}
+                format="12h"
               />
             </View>
 

--- a/frontend/components/EditItemModal.tsx
+++ b/frontend/components/EditItemModal.tsx
@@ -115,12 +115,7 @@ export function EditItemModal({
           {/* Form */}
           <ScrollView style={styles.form}>
             <View style={styles.field}>
-              <TimePickerInput
-                label="Time"
-                value={time}
-                onChange={setTime}
-                format="12h"
-              />
+              <TimePickerInput label="Time" value={time} onChange={setTime} format="12h" />
             </View>
 
             <View style={styles.field}>

--- a/frontend/components/TimePickerInput.tsx
+++ b/frontend/components/TimePickerInput.tsx
@@ -1,0 +1,193 @@
+import { Colors } from '@/constants/theme';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import React, { useState } from 'react';
+import {
+  Modal,
+  Platform,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+interface TimePickerInputProps {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  format?: '24h' | '12h';
+  style?: StyleProp<ViewStyle>;
+}
+
+function parseValue(value: string, format: '24h' | '12h'): Date {
+  const base = new Date();
+  base.setSeconds(0, 0);
+
+  if (!value) return base;
+
+  if (format === '24h') {
+    const parts = value.split(':');
+    if (parts.length >= 2) {
+      const h = parseInt(parts[0], 10);
+      const m = parseInt(parts[1], 10);
+      if (!isNaN(h) && !isNaN(m)) {
+        base.setHours(h, m);
+        return base;
+      }
+    }
+  } else {
+    // "h:mm AM/PM"
+    const match = value.match(/^(\d+):(\d+)\s*(AM|PM)$/i);
+    if (match) {
+      let h = parseInt(match[1], 10);
+      const m = parseInt(match[2], 10);
+      const meridiem = match[3].toUpperCase();
+      if (meridiem === 'PM' && h !== 12) h += 12;
+      if (meridiem === 'AM' && h === 12) h = 0;
+      base.setHours(h, m);
+      return base;
+    }
+  }
+
+  return base;
+}
+
+function formatOutput(date: Date, format: '24h' | '12h'): string {
+  if (format === '24h') {
+    const h = String(date.getHours()).padStart(2, '0');
+    const m = String(date.getMinutes()).padStart(2, '0');
+    return `${h}:${m}`;
+  }
+  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+}
+
+function displayTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+}
+
+export function TimePickerInput({
+  label,
+  value,
+  onChange,
+  format = '24h',
+  style,
+}: TimePickerInputProps) {
+  const currentDate = parseValue(value, format);
+  const [showPicker, setShowPicker] = useState(false);
+  const [tempDate, setTempDate] = useState(currentDate);
+
+  const open = () => {
+    setTempDate(parseValue(value, format));
+    setShowPicker(true);
+  };
+
+  const confirm = () => {
+    setShowPicker(false);
+    onChange(formatOutput(tempDate, format));
+  };
+
+  const cancel = () => {
+    setShowPicker(false);
+  };
+
+  return (
+    <View style={style}>
+      <Text style={styles.label}>{label}</Text>
+      <TouchableOpacity style={styles.input} onPress={open} activeOpacity={0.7}>
+        <Text style={value ? styles.inputText : styles.inputPlaceholder}>
+          {value ? displayTime(currentDate) : 'Select a time'}
+        </Text>
+      </TouchableOpacity>
+
+      {Platform.OS === 'ios' && showPicker && (
+        <Modal transparent animationType="slide">
+          <View style={styles.modalOverlay}>
+            <View style={styles.pickerContainer}>
+              <View style={styles.pickerHeader}>
+                <TouchableOpacity onPress={cancel}>
+                  <Text style={styles.pickerHeaderCancel}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={confirm}>
+                  <Text style={styles.pickerHeaderDone}>Done</Text>
+                </TouchableOpacity>
+              </View>
+              <DateTimePicker
+                value={tempDate}
+                mode="time"
+                display="spinner"
+                onChange={(_, date) => setTempDate(date ?? tempDate)}
+              />
+            </View>
+          </View>
+        </Modal>
+      )}
+
+      {Platform.OS === 'android' && showPicker && (
+        <DateTimePicker
+          value={currentDate}
+          mode="time"
+          is24Hour={false}
+          display="default"
+          onChange={(_, date) => {
+            setShowPicker(false);
+            if (date) onChange(formatOutput(date, format));
+          }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.light.text,
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: Colors.light.background,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  inputText: {
+    fontSize: 16,
+    color: Colors.light.text,
+  },
+  inputPlaceholder: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  pickerContainer: {
+    backgroundColor: Colors.light.surface,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingBottom: 30,
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  pickerHeaderCancel: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+  },
+  pickerHeaderDone: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.primary,
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@clerk/clerk-expo": "^2.19.22",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "~2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "~2.9.5",
     "@react-navigation/native": "^7.1.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sophros",
   "main": "expo-router/entry",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: ~2.2.0
         version: 2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))
+      '@react-native-community/datetimepicker':
+        specifier: 8.4.4
+        version: 8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@react-navigation/bottom-tabs':
         specifier: ^7.4.0
         version: 7.13.0(@react-navigation/native@7.1.28(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -1337,6 +1340,19 @@ packages:
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
+
+  '@react-native-community/datetimepicker@8.4.4':
+    resolution: {integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
@@ -6781,6 +6797,14 @@ snapshots:
     dependencies:
       merge-options: 3.0.4
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10)
 
   '@react-native/assets-registry@0.81.5': {}
 


### PR DESCRIPTION
## Summary

Replaces the plain TextInput time and date fields with real native pickers (iOS spinner modal, Android clock and calendar dialog) and fixes keyboard-avoiding layout across auth, onboarding, and profile screens so the software keyboard never hides what the user is typing.

Two new reusable components drive it: TimePickerInput (24h or 12h output format) and DatePickerInput (YYYY-MM-DD output with a clear button). Every screen that was typing times or dates by hand (onboarding step 5, profile edit, the schedule EditItemModal) now uses these. The auth, onboarding, and profile screens wrap their scrollable content in KeyboardAvoidingView with behavior padding so inputs stay visible when the keyboard opens.

## Issues

Closes #169
Closes #171
