### PR TITLE
feat: add frontend testing suite (Jest + RNTL, 145 tests)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -70,6 +70,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     defaults:
       run:
@@ -107,7 +108,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm test --ci
+        run: pnpm test --ci --forceExit
 
   build-android:
     name: Build Android

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -67,6 +67,48 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.13.1"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.0
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test --ci
+
   build-android:
     name: Build Android
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .expo/
 android/
 ios/
+.worktrees/

--- a/docs/testing/VerificationTestInventory.md
+++ b/docs/testing/VerificationTestInventory.md
@@ -1,8 +1,11 @@
 | Test Case ID | Level (Unit/Int/System) | Requirement ID | Tool              | Automated? | CI Integrated?                    | Evidence Link | Frequency |
 |-------------|--------------------------|----------------|-------------------|------------|-----------------------------------|---------------|-----------|
 | TR-1        | Unit                     | FR-1           | Pytest            | Yes        | Yes                               | [click](https://github.com/emersonmaddock/sophros/actions/workflows/backend-ci.yml)        | Commit    |
+| TR-1b       | Unit                     | FR-1           | Jest (RNTL)       | Yes        | Yes                               | [click](https://github.com/emersonmaddock/sophros/actions/workflows/frontend-ci.yml)       | Commit    |
 | TR-2        | Int                      | FR-2           | Manual            | No         | No                                | [click](https://github.com/emersonmaddock/sophros/blob/main/docs/testing/02.07.26_clerk_test.md)              | Biweekly  |
+| TR-2b       | Unit                     | FR-2           | Jest (RNTL)       | Yes        | Yes                               | [click](https://github.com/emersonmaddock/sophros/actions/workflows/frontend-ci.yml)       | Commit    |
 | TR-3        | Unit                     | FR-3           | Pytest            | Yes    | Yes | [click](https://github.com/emersonmaddock/sophros/actions/runs/22743564339/job/65962353252)           | Commit    |
+| TR-3b       | Unit                     | FR-3           | Jest (RNTL)       | Yes        | Yes                               | [click](https://github.com/emersonmaddock/sophros/actions/workflows/frontend-ci.yml)       | Commit    |
 | TR-4        | Unit                     | FR-4           | Pytest            | Not yet    | Not yet (expected March 7)        | N/A           | Weekly    |
 | TR-5        | Int                      | FR-5           | Manual            | No         | No                                | N/A           | Biweekly  |
 | TR-6        | System                   | FR-6           | Manual            | No         | No                                | [click](https://github.com/emersonmaddock/sophros/blob/main/docs/testing/03.07.26_meal_test.md)           | Biweekly  |

--- a/frontend/__tests__/hooks/useOnboarding.test.tsx
+++ b/frontend/__tests__/hooks/useOnboarding.test.tsx
@@ -212,7 +212,7 @@ describe('useOnboarding', () => {
         gender: 'male',
         activity_level: 'moderate',
       }),
-      'mock-token',
+      'mock-token'
     );
   });
 

--- a/frontend/__tests__/hooks/useOnboarding.test.tsx
+++ b/frontend/__tests__/hooks/useOnboarding.test.tsx
@@ -227,4 +227,26 @@ describe('useOnboarding', () => {
     expect(submitResult!).toBe(false);
     expect(mockCreateUser).not.toHaveBeenCalled();
   });
+
+  it('submit() sets error when createUser throws', async () => {
+    mockCreateUser.mockRejectedValueOnce(new Error('Network error'));
+    const { result } = renderOnboarding();
+
+    // Set all required fields to valid values first
+    act(() => {
+      result.current.updateField('age', VALID_AGE);
+      result.current.updateField('gender', 'male');
+      result.current.updateField('weight', VALID_WEIGHT);
+      result.current.updateField('height', VALID_HEIGHT);
+      result.current.updateField('activityLevel', 'moderate');
+    });
+
+    let success: boolean;
+    await act(async () => {
+      success = await result.current.submit();
+    });
+
+    expect(success!).toBe(false);
+    expect(result.current.error).toBe('Network error');
+  });
 });

--- a/frontend/__tests__/hooks/useOnboarding.test.tsx
+++ b/frontend/__tests__/hooks/useOnboarding.test.tsx
@@ -1,0 +1,230 @@
+import { OnboardingProvider, useOnboarding } from '@/hooks/useOnboarding';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import React from 'react';
+
+// Mocks
+jest.mock('@/contexts/UserContext', () => ({
+  useUser: jest.fn(() => ({ refreshUser: jest.fn() })),
+}));
+jest.mock('@/lib/api-client', () => ({
+  createUser: jest.fn().mockResolvedValue({}),
+}));
+
+import { createUser } from '@/lib/api-client';
+
+const mockCreateUser = createUser as jest.MockedFunction<typeof createUser>;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <OnboardingProvider>{children}</OnboardingProvider>
+);
+
+function renderOnboarding() {
+  return renderHook(() => useOnboarding(), { wrapper });
+}
+
+// Valid data for all sections (age 25-120, weight 20-300, height 100-250)
+const VALID_AGE = '25';
+const VALID_WEIGHT = '70';
+const VALID_HEIGHT = '170';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // --- initial state ---
+
+  it('has correct initial state', () => {
+    const { result } = renderOnboarding();
+    expect(result.current.data.age).toBe('');
+    expect(result.current.data.gender).toBeNull();
+    expect(result.current.errors).toEqual({});
+    expect(result.current.loading).toBe(false);
+  });
+
+  // --- updateField ---
+
+  it('updateField("age", "25") updates data.age', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('age', '25');
+    });
+    expect(result.current.data.age).toBe('25');
+  });
+
+  it('updating a field clears its existing error', async () => {
+    const { result } = renderOnboarding();
+
+    // First trigger an error on age
+    act(() => {
+      result.current.validate();
+    });
+    expect(result.current.errors.age).toBeDefined();
+
+    // Now update age — error should clear
+    act(() => {
+      result.current.updateField('age', '25');
+    });
+    expect(result.current.errors.age).toBeUndefined();
+  });
+
+  // --- validate ---
+
+  it('validate() with all empty fields returns false and sets errors', () => {
+    const { result } = renderOnboarding();
+    let isValid: boolean;
+    act(() => {
+      isValid = result.current.validate();
+    });
+    expect(isValid!).toBe(false);
+    expect(result.current.errors.age).toBeDefined();
+    expect(result.current.errors.weight).toBeDefined();
+    expect(result.current.errors.height).toBeDefined();
+    expect(result.current.errors.gender).toBeDefined();
+    expect(result.current.errors.activityLevel).toBeDefined();
+  });
+
+  it('validate() with valid values returns true and no errors', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('age', VALID_AGE);
+      result.current.updateField('weight', VALID_WEIGHT);
+      result.current.updateField('height', VALID_HEIGHT);
+      result.current.updateField('gender', 'male');
+      result.current.updateField('activityLevel', 'moderate');
+    });
+    let isValid: boolean;
+    act(() => {
+      isValid = result.current.validate();
+    });
+    expect(isValid!).toBe(true);
+    expect(result.current.errors).toEqual({});
+  });
+
+  // --- section completion ---
+
+  it('isSection1Complete() is false when age is empty', () => {
+    const { result } = renderOnboarding();
+    expect(result.current.isSection1Complete()).toBe(false);
+  });
+
+  it('isSection1Complete() is true when age is valid and gender is set', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('age', VALID_AGE);
+      result.current.updateField('gender', 'male');
+    });
+    expect(result.current.isSection1Complete()).toBe(true);
+  });
+
+  it('isSection2Complete() is false when weight and height are empty', () => {
+    const { result } = renderOnboarding();
+    expect(result.current.isSection2Complete()).toBe(false);
+  });
+
+  it('isSection2Complete() is true when weight and height are valid', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('weight', VALID_WEIGHT);
+      result.current.updateField('height', VALID_HEIGHT);
+    });
+    expect(result.current.isSection2Complete()).toBe(true);
+  });
+
+  it('isSection3Complete() is true for male (non-female)', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('gender', 'male');
+    });
+    expect(result.current.isSection3Complete()).toBe(true);
+  });
+
+  it('isSection3Complete() is false for female when pregnancyStatus is not set', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('gender', 'female');
+    });
+    expect(result.current.isSection3Complete()).toBe(false);
+  });
+
+  it('isSection3Complete() is true for female when pregnancyStatus is set', () => {
+    const { result } = renderOnboarding();
+    act(() => {
+      result.current.updateField('gender', 'female');
+      result.current.updateField('pregnancyStatus', 'not_pregnant');
+    });
+    expect(result.current.isSection3Complete()).toBe(true);
+  });
+
+  it('canSubmit() is true only when all sections are complete', () => {
+    const { result } = renderOnboarding();
+
+    // Start with incomplete
+    expect(result.current.canSubmit()).toBe(false);
+
+    // Fill all required fields
+    act(() => {
+      result.current.updateField('age', VALID_AGE);
+      result.current.updateField('gender', 'male');
+      result.current.updateField('weight', VALID_WEIGHT);
+      result.current.updateField('height', VALID_HEIGHT);
+      result.current.updateField('activityLevel', 'moderate');
+    });
+
+    expect(result.current.canSubmit()).toBe(true);
+  });
+
+  // --- submit ---
+
+  it('submit() with valid data calls createUser and returns true', async () => {
+    mockCreateUser.mockResolvedValueOnce({} as any);
+    const { result } = renderOnboarding();
+
+    act(() => {
+      result.current.updateField('age', VALID_AGE);
+      result.current.updateField('gender', 'male');
+      result.current.updateField('weight', VALID_WEIGHT);
+      result.current.updateField('height', VALID_HEIGHT);
+      result.current.updateField('activityLevel', 'moderate');
+    });
+
+    let submitResult: boolean;
+    await act(async () => {
+      submitResult = await result.current.submit();
+    });
+
+    expect(submitResult!).toBe(true);
+    expect(mockCreateUser).toHaveBeenCalledTimes(1);
+    expect(mockCreateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'test@example.com',
+        age: 25,
+        weight: 70,
+        height: 170,
+        gender: 'male',
+        activity_level: 'moderate',
+      }),
+      'mock-token',
+    );
+  });
+
+  it('submit() with invalid data does NOT call createUser and returns false', async () => {
+    const { result } = renderOnboarding();
+
+    let submitResult: boolean;
+    await act(async () => {
+      submitResult = await result.current.submit();
+    });
+
+    expect(submitResult!).toBe(false);
+    expect(mockCreateUser).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/hooks/useScheduleEditing.test.tsx
+++ b/frontend/__tests__/hooks/useScheduleEditing.test.tsx
@@ -1,0 +1,316 @@
+import type {
+  DailyMealPlanOutput,
+  MealSlotTargetOutput,
+  Recipe,
+  SavedMealPlanResponse,
+  WeeklyMealPlanOutput,
+} from '@/api/types.gen';
+import { useScheduleEditing } from '@/hooks/useScheduleEditing';
+import type { WeeklyScheduleItem } from '@/types/schedule';
+import { createWrapper } from '@/__tests__/test-utils';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@/lib/queries/mealPlan', () => ({
+  useSaveMealPlanMutation: jest.fn(() => ({
+    mutateAsync: jest.fn().mockResolvedValue({}),
+  })),
+}));
+
+import { useSaveMealPlanMutation } from '@/lib/queries/mealPlan';
+
+const mockUseSaveMealPlanMutation = useSaveMealPlanMutation as jest.MockedFunction<
+  typeof useSaveMealPlanMutation
+>;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeRecipe(id: string, title: string, calories = 400): Recipe {
+  return {
+    id,
+    title,
+    nutrients: { calories, protein: 30, carbohydrates: 50, fat: 10 },
+    preparation_time_minutes: 20,
+  };
+}
+
+function makeSlot(
+  slotName: MealSlotTargetOutput['slot_name'],
+  time: string,
+  calories: number,
+  recipe?: Recipe,
+): MealSlotTargetOutput {
+  return {
+    slot_name: slotName,
+    time,
+    calories,
+    protein: recipe?.nutrients.protein ?? 0,
+    carbohydrates: recipe?.nutrients.carbohydrates ?? 0,
+    fat: recipe?.nutrients.fat ?? 0,
+    plan: recipe ? { main_recipe: recipe, alternatives: [] } : null,
+  };
+}
+
+function makeDailyPlan(
+  day: DailyMealPlanOutput['day'],
+  slots: MealSlotTargetOutput[],
+): DailyMealPlanOutput {
+  return {
+    day,
+    slots,
+    exercise: null,
+    total_calories: slots.reduce(
+      (sum, s) => sum + (s.plan?.main_recipe?.nutrients.calories ?? s.calories),
+      0,
+    ),
+    total_protein: 0,
+    total_carbs: 0,
+    total_fat: 0,
+  };
+}
+
+function makeWeeklyPlan(): WeeklyMealPlanOutput {
+  const recipe = makeRecipe('recipe-1', 'Oatmeal', 350);
+  const slot = makeSlot('Breakfast', '08:00:00', 350, recipe);
+  const monday = makeDailyPlan('Monday', [slot]);
+  return {
+    daily_plans: [monday],
+    total_weekly_calories: monday.total_calories,
+  };
+}
+
+function makeSavedPlan(planData: WeeklyMealPlanOutput): SavedMealPlanResponse {
+  return {
+    id: 1,
+    week_start_date: '2026-03-23',
+    plan_data: planData,
+    created_at: '2026-03-23T00:00:00Z',
+    updated_at: '2026-03-23T00:00:00Z',
+  };
+}
+
+const WEEK_START = '2026-03-23';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useScheduleEditing', () => {
+  let mutateAsync: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mutateAsync = jest.fn().mockResolvedValue({});
+    mockUseSaveMealPlanMutation.mockReturnValue({ mutateAsync } as any);
+  });
+
+  it('initializes rawPlan from savedPlan.plan_data on mount', () => {
+    const weeklyPlan = makeWeeklyPlan();
+    const savedPlan = makeSavedPlan(weeklyPlan);
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.rawPlan).toEqual(weeklyPlan);
+  });
+
+  it('isDirty is false initially', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('removeItem sets isDirty to true and updates rawPlan', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.removeItem('Monday', 'recipe-1');
+    });
+
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.rawPlan?.daily_plans[0].slots).toHaveLength(0);
+  });
+
+  it('addItem sets isDirty to true and updates rawPlan', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    const newItem: WeeklyScheduleItem = {
+      id: 'recipe-new',
+      time: '12:00 PM',
+      title: 'New Lunch',
+      duration: '30 min',
+      type: 'meal',
+      calories: 500,
+    };
+
+    act(() => {
+      result.current.addItem('Monday', newItem);
+    });
+
+    expect(result.current.isDirty).toBe(true);
+    // The plan originally had 1 slot; after addItem it should have 2
+    expect(result.current.rawPlan?.daily_plans[0].slots).toHaveLength(2);
+  });
+
+  it('editItem (remove + add) sets isDirty to true', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    const updatedItem: WeeklyScheduleItem = {
+      id: 'recipe-updated',
+      time: '8:00 AM',
+      title: 'Updated Oatmeal',
+      duration: '20 min',
+      type: 'meal',
+      calories: 400,
+    };
+
+    act(() => {
+      result.current.editItem('Monday', 'recipe-1', updatedItem);
+    });
+
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  it('getScheduleItems returns mapped items for the given day index', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    // Day index 0 = Monday
+    const items = result.current.getScheduleItems(0);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe('Oatmeal');
+    expect(items[0].type).toBe('meal');
+  });
+
+  it('getScheduleItems returns empty array for a day with no plan', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    // Day index 1 = Tuesday (not in the plan)
+    const items = result.current.getScheduleItems(1);
+    expect(items).toHaveLength(0);
+  });
+
+  it('save() when not dirty does NOT call mutateAsync', async () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('save() when dirty calls mutateAsync with correct args and sets isDirty to false', async () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    // Make it dirty first
+    act(() => {
+      result.current.removeItem('Monday', 'recipe-1');
+    });
+    expect(result.current.isDirty).toBe(true);
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        week_start_date: WEEK_START,
+        plan_data: expect.any(Object),
+      }),
+    );
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  // --- statusText ---
+
+  it('statusText is "AI-optimized" when saveStatus is idle', () => {
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.statusText).toBe('AI-optimized');
+  });
+
+  it('statusText reflects saving/saved/error states', async () => {
+    // Use a promise we control to test the "saving" state
+    let resolveSave!: (v: unknown) => void;
+    const savePromise = new Promise((res) => {
+      resolveSave = res;
+    });
+    mutateAsync.mockReturnValueOnce(savePromise);
+
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    // Make dirty then trigger save
+    act(() => {
+      result.current.removeItem('Monday', 'recipe-1');
+    });
+
+    // Start save without awaiting
+    act(() => {
+      result.current.save();
+    });
+
+    expect(result.current.statusText).toBe('Saving...');
+
+    // Resolve the save
+    await act(async () => {
+      resolveSave({});
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.statusText).toBe('Changes saved');
+    });
+  });
+
+  it('statusText is "Error saving" when save fails', async () => {
+    mutateAsync.mockRejectedValueOnce(new Error('Network error'));
+
+    const savedPlan = makeSavedPlan(makeWeeklyPlan());
+    const { result } = renderHook(() => useScheduleEditing(savedPlan, WEEK_START), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.removeItem('Monday', 'recipe-1');
+    });
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.statusText).toBe('Error saving');
+  });
+});

--- a/frontend/__tests__/hooks/useScheduleEditing.test.tsx
+++ b/frontend/__tests__/hooks/useScheduleEditing.test.tsx
@@ -43,7 +43,7 @@ function makeSlot(
   slotName: MealSlotTargetOutput['slot_name'],
   time: string,
   calories: number,
-  recipe?: Recipe,
+  recipe?: Recipe
 ): MealSlotTargetOutput {
   return {
     slot_name: slotName,
@@ -58,7 +58,7 @@ function makeSlot(
 
 function makeDailyPlan(
   day: DailyMealPlanOutput['day'],
-  slots: MealSlotTargetOutput[],
+  slots: MealSlotTargetOutput[]
 ): DailyMealPlanOutput {
   return {
     day,
@@ -66,7 +66,7 @@ function makeDailyPlan(
     exercise: null,
     total_calories: slots.reduce(
       (sum, s) => sum + (s.plan?.main_recipe?.nutrients.calories ?? s.calories),
-      0,
+      0
     ),
     total_protein: 0,
     total_carbs: 0,
@@ -252,7 +252,7 @@ describe('useScheduleEditing', () => {
       expect.objectContaining({
         week_start_date: WEEK_START,
         plan_data: expect.any(Object),
-      }),
+      })
     );
     expect(result.current.isDirty).toBe(false);
   });

--- a/frontend/__tests__/hooks/useScheduleEditing.test.tsx
+++ b/frontend/__tests__/hooks/useScheduleEditing.test.tsx
@@ -104,9 +104,17 @@ describe('useScheduleEditing', () => {
   let mutateAsync: jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     mutateAsync = jest.fn().mockResolvedValue({});
     mockUseSaveMealPlanMutation.mockReturnValue({ mutateAsync } as any);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
   });
 
   it('initializes rawPlan from savedPlan.plan_data on mount', () => {
@@ -292,6 +300,11 @@ describe('useScheduleEditing', () => {
 
     await waitFor(() => {
       expect(result.current.statusText).toBe('Changes saved');
+    });
+
+    // Advance past the 2-second reset timer so it doesn't leak
+    act(() => {
+      jest.advanceTimersByTime(2000);
     });
   });
 

--- a/frontend/__tests__/hooks/useUserProfile.test.tsx
+++ b/frontend/__tests__/hooks/useUserProfile.test.tsx
@@ -72,7 +72,7 @@ function makeClerkUser(overrides: Record<string, unknown> = {}) {
 
 function setupMocks(
   backendUser: ReturnType<typeof makeBackendUser> | null,
-  clerkUser: ReturnType<typeof makeClerkUser> | null,
+  clerkUser: ReturnType<typeof makeClerkUser> | null
 ) {
   mockUseContextUser.mockReturnValue({
     user: backendUser as any,
@@ -126,7 +126,7 @@ describe('useUserProfile', () => {
     setupMocks(makeBackendUser({ height: 180, show_imperial: true }), makeClerkUser());
     const { result } = renderHook(() => useUserProfile());
     // 180 cm → ~70.87 inches → 5 feet 11 inches
-    expect(result.current.profile?.height).toBe("5' 11\"");
+    expect(result.current.profile?.height).toBe('5\' 11"');
   });
 
   it('formats weight in kg when show_imperial is false', () => {

--- a/frontend/__tests__/hooks/useUserProfile.test.tsx
+++ b/frontend/__tests__/hooks/useUserProfile.test.tsx
@@ -1,0 +1,167 @@
+import { useUserProfile } from '@/hooks/useUserProfile';
+import { renderHook } from '@testing-library/react-native';
+
+// Mock UserContext — Clerk's useUser is already mocked globally in jest.setup.ts,
+// but we need per-test control so we override it locally here.
+jest.mock('@/contexts/UserContext', () => ({
+  useUser: jest.fn(),
+}));
+
+jest.mock('@clerk/clerk-expo', () => ({
+  useAuth: jest.fn(() => ({
+    isSignedIn: true,
+    userId: 'test-user-id',
+    getToken: jest.fn().mockResolvedValue('mock-token'),
+  })),
+  useUser: jest.fn(() => ({
+    user: {
+      id: 'test-user-id',
+      firstName: 'Test',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+    },
+    isLoaded: true,
+  })),
+  useSignIn: jest.fn(() => ({
+    signIn: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  })),
+  useSignUp: jest.fn(() => ({
+    signUp: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  })),
+  useClerk: jest.fn(() => ({ signOut: jest.fn() })),
+  ClerkProvider: ({ children }: { children: unknown }) => children,
+}));
+
+import { useUser as useContextUser } from '@/contexts/UserContext';
+import { useUser as useClerkUser } from '@clerk/clerk-expo';
+
+const mockUseContextUser = useContextUser as jest.MockedFunction<typeof useContextUser>;
+const mockClerkUseUser = useClerkUser as jest.MockedFunction<typeof useClerkUser>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeBackendUser(overrides: Record<string, unknown> = {}) {
+  return {
+    email: 'test@example.com',
+    age: 30,
+    weight: 80,
+    height: 180,
+    show_imperial: false,
+    gender: 'male' as const,
+    activity_level: 'moderate' as const,
+    pregnancy_status: undefined,
+    ...overrides,
+  };
+}
+
+function makeClerkUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'clerk-user-id',
+    firstName: 'Test',
+    lastName: 'User',
+    primaryEmailAddress: { emailAddress: 'test@example.com' },
+    ...overrides,
+  };
+}
+
+function setupMocks(
+  backendUser: ReturnType<typeof makeBackendUser> | null,
+  clerkUser: ReturnType<typeof makeClerkUser> | null,
+) {
+  mockUseContextUser.mockReturnValue({
+    user: backendUser as any,
+    isOnboarded: !!backendUser,
+    loading: false,
+    error: null,
+    fetchUser: jest.fn(),
+    refreshUser: jest.fn(),
+    updateUserProfile: jest.fn(),
+    clearUser: jest.fn(),
+  });
+
+  mockClerkUseUser.mockReturnValue({
+    user: clerkUser as any,
+    isLoaded: true,
+    isSignedIn: !!clerkUser,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useUserProfile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset to default mocks
+    setupMocks(makeBackendUser(), makeClerkUser());
+  });
+
+  it('returns null profile when backendUser is null', () => {
+    setupMocks(null, makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile).toBeNull();
+  });
+
+  it('returns null profile when Clerk user is null', () => {
+    setupMocks(makeBackendUser(), null);
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile).toBeNull();
+  });
+
+  it('formats weight in lbs when show_imperial is true', () => {
+    setupMocks(makeBackendUser({ weight: 80, show_imperial: true }), makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    // 80 kg / 0.453592 = ~176.37 lbs → "176.4 lbs"
+    expect(result.current.profile?.weight).toBe('176.4 lbs');
+  });
+
+  it('formats height in feet/inches when show_imperial is true', () => {
+    setupMocks(makeBackendUser({ height: 180, show_imperial: true }), makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    // 180 cm → ~70.87 inches → 5 feet 11 inches
+    expect(result.current.profile?.height).toBe("5' 11\"");
+  });
+
+  it('formats weight in kg when show_imperial is false', () => {
+    setupMocks(makeBackendUser({ weight: 80, show_imperial: false }), makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile?.weight).toBe('80.0 kg');
+  });
+
+  it('formats height in cm when show_imperial is false', () => {
+    setupMocks(makeBackendUser({ height: 180, show_imperial: false }), makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile?.height).toBe('180 cm');
+  });
+
+  it('maps activityLevel "moderate" to "Moderately Active"', () => {
+    setupMocks(makeBackendUser({ activity_level: 'moderate' }), makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile?.activityLevel).toBe('Moderately Active');
+  });
+
+  it('maps gender "male" to "Male"', () => {
+    setupMocks(makeBackendUser({ gender: 'male' }), makeClerkUser());
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile?.gender).toBe('Male');
+  });
+
+  it('constructs fullName from firstName and lastName', () => {
+    setupMocks(makeBackendUser(), makeClerkUser({ firstName: 'Jane', lastName: 'Doe' }));
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile?.fullName).toBe('Jane Doe');
+  });
+
+  it('falls back to "User" when both firstName and lastName are empty', () => {
+    setupMocks(makeBackendUser(), makeClerkUser({ firstName: '', lastName: '' }));
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile?.fullName).toBe('User');
+  });
+});

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { screen } from '@testing-library/react-native';
+import { renderWithProviders } from '@/__tests__/test-utils';
+import DashboardPage from '@/app/(tabs)/index';
+
+// theme.ts calls Platform.select at module-init level; mock to avoid ordering issues.
+jest.mock('@/constants/theme', () => ({
+  Colors: {
+    light: {
+      text: '#111827',
+      textMuted: '#6B7280',
+      background: '#F8FAFC',
+      surface: '#FFFFFF',
+      primary: '#2B9D8F',
+      primaryDark: '#1F6D63',
+      tint: '#2B9D8F',
+      secondary: '#FFB74D',
+      success: '#22C55E',
+      error: '#EF4444',
+      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
+    },
+  },
+  Shadows: { card: {} },
+  Layout: { cardRadius: 16 },
+  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
+}));
+
+// Mock all data-fetching hooks used by the dashboard
+jest.mock('@/lib/queries/mealPlan', () => ({
+  useSavedWeekPlanQuery: jest.fn(() => ({ data: null, isLoading: false, error: null })),
+  useGenerateWeekPlanMutation: jest.fn(() => ({ mutateAsync: jest.fn(), isPending: false })),
+}));
+
+jest.mock('@/lib/queries/user', () => ({
+  useUserQuery: jest.fn(() => ({ data: null, isLoading: false })),
+  useUserTargetsQuery: jest.fn(() => ({ data: null, isLoading: false })),
+}));
+
+// Note: the home screen imports useUser from @clerk/clerk-expo (as useClerkUser alias),
+// not from @/contexts/UserContext — the global mock in jest.setup.ts covers this.
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => children,
+    Svg: ({ children }: { children: React.ReactNode }) => children,
+    Path: () => null,
+    Circle: () => null,
+    G: () => null,
+  };
+});
+
+import { useSavedWeekPlanQuery } from '@/lib/queries/mealPlan';
+import { useUserQuery, useUserTargetsQuery } from '@/lib/queries/user';
+import { useUser as useClerkUser } from '@clerk/clerk-expo';
+
+describe('DashboardPage (Home)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset to default null-data state
+    (useSavedWeekPlanQuery as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+    (useUserQuery as jest.Mock).mockReturnValue({ data: null, isLoading: false });
+    (useUserTargetsQuery as jest.Mock).mockReturnValue({ data: null, isLoading: false });
+  });
+
+  it('renders without crashing when all data is null', () => {
+    renderWithProviders(<DashboardPage />);
+    // The greeting is always rendered
+    expect(screen.getByText(/Good (Morning|Afternoon|Evening)/)).toBeTruthy();
+  });
+
+  it('renders the Health Score section', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText('Health Score')).toBeTruthy();
+  });
+
+  it("renders the \"No meals planned yet\" message when there is no saved plan", () => {
+    renderWithProviders(<DashboardPage />);
+    expect(
+      screen.getByText(/No meals planned yet/i)
+    ).toBeTruthy();
+  });
+
+  it("shows the user's first name in the greeting when Clerk user has firstName", () => {
+    // The global mock in jest.setup.ts returns { user: { firstName: 'Test', ... } }
+    // so the greeting should say "Test" rather than "there"
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText(/Test/)).toBeTruthy();
+  });
+
+  it('renders macro nutrient section labels', () => {
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText("Today's Macros")).toBeTruthy();
+  });
+});

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -5,7 +5,10 @@ import DashboardPage from '@/app/(tabs)/index';
 
 // Override the global Clerk mock to make useUser a jest.fn() for per-test control
 jest.mock('@clerk/clerk-expo', () => ({
-  useAuth: jest.fn(() => ({ isSignedIn: true, getToken: jest.fn().mockResolvedValue('mock-token') })),
+  useAuth: jest.fn(() => ({
+    isSignedIn: true,
+    getToken: jest.fn().mockResolvedValue('mock-token'),
+  })),
   useUser: jest.fn(() => ({
     user: {
       id: 'test-user-id',
@@ -16,8 +19,16 @@ jest.mock('@clerk/clerk-expo', () => ({
     },
     isLoaded: true,
   })),
-  useSignIn: jest.fn(() => ({ signIn: { create: jest.fn() }, isLoaded: true, setActive: jest.fn() })),
-  useSignUp: jest.fn(() => ({ signUp: { create: jest.fn() }, isLoaded: true, setActive: jest.fn() })),
+  useSignIn: jest.fn(() => ({
+    signIn: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  })),
+  useSignUp: jest.fn(() => ({
+    signUp: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  })),
   useClerk: jest.fn(() => ({ signOut: jest.fn() })),
   ClerkProvider: ({ children }: { children: unknown }) => children,
 }));
@@ -82,11 +93,9 @@ describe('DashboardPage (Home)', () => {
     expect(screen.getByText('Health Score')).toBeTruthy();
   });
 
-  it("renders the \"No meals planned yet\" message when there is no saved plan", () => {
+  it('renders the "No meals planned yet" message when there is no saved plan', () => {
     renderWithProviders(<DashboardPage />);
-    expect(
-      screen.getByText(/No meals planned yet/i)
-    ).toBeTruthy();
+    expect(screen.getByText(/No meals planned yet/i)).toBeTruthy();
   });
 
   it("shows the user's first name in the greeting when Clerk user has firstName", async () => {

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -1,28 +1,21 @@
 import React from 'react';
-import { screen } from '@testing-library/react-native';
+import { screen, waitFor } from '@testing-library/react-native';
 import { renderWithProviders } from '@/__tests__/test-utils';
 import DashboardPage from '@/app/(tabs)/index';
 
-// theme.ts calls Platform.select at module-init level; mock to avoid ordering issues.
-jest.mock('@/constants/theme', () => ({
-  Colors: {
-    light: {
-      text: '#111827',
-      textMuted: '#6B7280',
-      background: '#F8FAFC',
-      surface: '#FFFFFF',
-      primary: '#2B9D8F',
-      primaryDark: '#1F6D63',
-      tint: '#2B9D8F',
-      secondary: '#FFB74D',
-      success: '#22C55E',
-      error: '#EF4444',
-      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
+// Override the global Clerk mock to make useUser a jest.fn() for per-test control
+jest.mock('@clerk/clerk-expo', () => ({
+  ...jest.requireActual('@clerk/clerk-expo'),
+  useUser: jest.fn(() => ({
+    user: {
+      id: 'test-user-id',
+      firstName: 'Test',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
     },
-  },
-  Shadows: { card: {} },
-  Layout: { cardRadius: 16 },
-  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
+    isLoaded: true,
+  })),
 }));
 
 // Mock all data-fetching hooks used by the dashboard
@@ -58,7 +51,7 @@ jest.mock('react-native-svg', () => {
 
 import { useSavedWeekPlanQuery } from '@/lib/queries/mealPlan';
 import { useUserQuery, useUserTargetsQuery } from '@/lib/queries/user';
-import { useUser as useClerkUser } from '@clerk/clerk-expo';
+import { useUser } from '@clerk/clerk-expo';
 
 describe('DashboardPage (Home)', () => {
   beforeEach(() => {
@@ -92,11 +85,17 @@ describe('DashboardPage (Home)', () => {
     ).toBeTruthy();
   });
 
-  it("shows the user's first name in the greeting when Clerk user has firstName", () => {
-    // The global mock in jest.setup.ts returns { user: { firstName: 'Test', ... } }
-    // so the greeting should say "Test" rather than "there"
+  it("shows the user's first name in the greeting when Clerk user has firstName", async () => {
+    // Override the global Clerk mock for this test only
+    (useUser as jest.Mock).mockReturnValueOnce({
+      user: { firstName: 'Alice', lastName: 'Smith' },
+      isLoaded: true,
+    });
+
     renderWithProviders(<DashboardPage />);
-    expect(screen.getByText(/Test/)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText(/Alice/)).toBeTruthy();
+    });
   });
 
   it('renders macro nutrient section labels', () => {

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -103,4 +103,18 @@ describe('DashboardPage (Home)', () => {
     renderWithProviders(<DashboardPage />);
     expect(screen.getByText("Today's Macros")).toBeTruthy();
   });
+
+  it('shows loading indicator when isLoading: true', () => {
+    // Mock the query to return isLoading: true
+    (useSavedWeekPlanQuery as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    renderWithProviders(<DashboardPage />);
+
+    // Check for ActivityIndicator by testID or by looking for the loading indicator
+    expect(screen.getByTestId('home-loading-indicator')).toBeTruthy();
+  });
 });

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -5,7 +5,7 @@ import DashboardPage from '@/app/(tabs)/index';
 
 // Override the global Clerk mock to make useUser a jest.fn() for per-test control
 jest.mock('@clerk/clerk-expo', () => ({
-  ...jest.requireActual('@clerk/clerk-expo'),
+  useAuth: jest.fn(() => ({ isSignedIn: true, getToken: jest.fn().mockResolvedValue('mock-token') })),
   useUser: jest.fn(() => ({
     user: {
       id: 'test-user-id',
@@ -16,6 +16,10 @@ jest.mock('@clerk/clerk-expo', () => ({
     },
     isLoaded: true,
   })),
+  useSignIn: jest.fn(() => ({ signIn: { create: jest.fn() }, isLoaded: true, setActive: jest.fn() })),
+  useSignUp: jest.fn(() => ({ signUp: { create: jest.fn() }, isLoaded: true, setActive: jest.fn() })),
+  useClerk: jest.fn(() => ({ signOut: jest.fn() })),
+  ClerkProvider: ({ children }: { children: unknown }) => children,
 }));
 
 // Mock all data-fetching hooks used by the dashboard

--- a/frontend/__tests__/screens/onboarding-step1.test.tsx
+++ b/frontend/__tests__/screens/onboarding-step1.test.tsx
@@ -2,28 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { OnboardingProvider } from '@/hooks/useOnboarding';
 import Step1Screen from '@/app/onboarding/step1';
-
-// theme.ts calls Platform.select at module-init level; mock to avoid ordering issues.
-jest.mock('@/constants/theme', () => ({
-  Colors: {
-    light: {
-      text: '#111827',
-      textMuted: '#6B7280',
-      background: '#F8FAFC',
-      surface: '#FFFFFF',
-      primary: '#2B9D8F',
-      primaryDark: '#1F6D63',
-      tint: '#2B9D8F',
-      secondary: '#FFB74D',
-      success: '#22C55E',
-      error: '#EF4444',
-      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
-    },
-  },
-  Shadows: { card: {} },
-  Layout: { cardRadius: 16 },
-  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
-}));
+import { router } from 'expo-router';
 
 // Mocks required by the onboarding hook and screen
 jest.mock('@/contexts/UserContext', () => ({
@@ -77,25 +56,24 @@ describe('Step1Screen (Onboarding)', () => {
 
   it('Continue button is disabled when age and gender are empty', () => {
     renderStep1();
-    // Use UNSAFE_getByProps to find the TouchableOpacity that has disabled=true
-    const disabledButton = screen.UNSAFE_getByProps({ disabled: true });
-    expect(disabledButton).toBeTruthy();
-    // Confirm it's the Continue button by checking its child text
-    expect(disabledButton.findByProps({ children: 'Continue' })).toBeTruthy();
+    // When the button is disabled, pressing it should not trigger navigation
+    fireEvent.press(screen.getByText('Continue'));
+    expect(router.push).not.toHaveBeenCalled();
   });
 
   it('Continue button becomes enabled after valid age and gender are provided', () => {
     renderStep1();
 
-    // Verify it starts disabled
-    expect(screen.UNSAFE_getByProps({ disabled: true })).toBeTruthy();
+    // Verify it starts disabled: pressing does nothing
+    fireEvent.press(screen.getByText('Continue'));
+    expect(router.push).not.toHaveBeenCalled();
 
     fireEvent.changeText(screen.getByPlaceholderText('Enter your age'), '25');
     fireEvent.press(screen.getByText('Male'));
 
-    // After valid input, the disabled button should no longer exist
-    const stillDisabled = screen.UNSAFE_queryByProps({ disabled: true });
-    expect(stillDisabled).toBeNull();
+    // After valid input, pressing Continue should navigate
+    fireEvent.press(screen.getByText('Continue'));
+    expect(router.push).toHaveBeenCalledWith('/onboarding/step2');
   });
 
   it('pressing gender option selects it', () => {

--- a/frontend/__tests__/screens/onboarding-step1.test.tsx
+++ b/frontend/__tests__/screens/onboarding-step1.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { OnboardingProvider } from '@/hooks/useOnboarding';
+import Step1Screen from '@/app/onboarding/step1';
+
+// theme.ts calls Platform.select at module-init level; mock to avoid ordering issues.
+jest.mock('@/constants/theme', () => ({
+  Colors: {
+    light: {
+      text: '#111827',
+      textMuted: '#6B7280',
+      background: '#F8FAFC',
+      surface: '#FFFFFF',
+      primary: '#2B9D8F',
+      primaryDark: '#1F6D63',
+      tint: '#2B9D8F',
+      secondary: '#FFB74D',
+      success: '#22C55E',
+      error: '#EF4444',
+      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
+    },
+  },
+  Shadows: { card: {} },
+  Layout: { cardRadius: 16 },
+  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
+}));
+
+// Mocks required by the onboarding hook and screen
+jest.mock('@/contexts/UserContext', () => ({
+  useUser: jest.fn(() => ({ refreshUser: jest.fn() })),
+}));
+
+jest.mock('@/lib/api-client', () => ({
+  createUser: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+// Wrap the screen in the required OnboardingProvider
+function renderStep1() {
+  return render(
+    <OnboardingProvider>
+      <Step1Screen />
+    </OnboardingProvider>
+  );
+}
+
+describe('Step1Screen (Onboarding)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    renderStep1();
+    expect(screen.getByText('Basic Information')).toBeTruthy();
+  });
+
+  it('renders the age input field', () => {
+    renderStep1();
+    expect(screen.getByPlaceholderText('Enter your age')).toBeTruthy();
+  });
+
+  it('renders gender (biological sex) selection options', () => {
+    renderStep1();
+    // SEX_OPTIONS has 'Male' and 'Female' labels
+    expect(screen.getByText('Male')).toBeTruthy();
+    expect(screen.getByText('Female')).toBeTruthy();
+  });
+
+  it('shows the step progress indicator', () => {
+    renderStep1();
+    expect(screen.getByText('Step 1 of 5')).toBeTruthy();
+  });
+
+  it('Continue button is disabled when age and gender are empty', () => {
+    renderStep1();
+    // Use UNSAFE_getByProps to find the TouchableOpacity that has disabled=true
+    const disabledButton = screen.UNSAFE_getByProps({ disabled: true });
+    expect(disabledButton).toBeTruthy();
+    // Confirm it's the Continue button by checking its child text
+    expect(disabledButton.findByProps({ children: 'Continue' })).toBeTruthy();
+  });
+
+  it('Continue button becomes enabled after valid age and gender are provided', () => {
+    renderStep1();
+
+    // Verify it starts disabled
+    expect(screen.UNSAFE_getByProps({ disabled: true })).toBeTruthy();
+
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your age'), '25');
+    fireEvent.press(screen.getByText('Male'));
+
+    // After valid input, the disabled button should no longer exist
+    const stillDisabled = screen.UNSAFE_queryByProps({ disabled: true });
+    expect(stillDisabled).toBeNull();
+  });
+
+  it('pressing gender option selects it', () => {
+    renderStep1();
+    // Press Male — no error should be thrown
+    fireEvent.press(screen.getByText('Male'));
+    // Pressing Female should also work
+    fireEvent.press(screen.getByText('Female'));
+    expect(screen.getByText('Female')).toBeTruthy();
+  });
+});

--- a/frontend/__tests__/screens/sign-in.test.tsx
+++ b/frontend/__tests__/screens/sign-in.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { useSignIn } from '@clerk/clerk-expo';
+import { renderWithProviders } from '@/__tests__/test-utils';
+import SignInScreen from '@/app/(auth)/sign-in';
+
+// theme.ts calls Platform.select at module-init level; mock the whole module to
+// avoid relying on the Platform mock being established before module evaluation.
+jest.mock('@/constants/theme', () => ({
+  Colors: {
+    light: {
+      text: '#111827',
+      textMuted: '#6B7280',
+      background: '#F8FAFC',
+      surface: '#FFFFFF',
+      primary: '#2B9D8F',
+      primaryDark: '#1F6D63',
+      tint: '#2B9D8F',
+      secondary: '#FFB74D',
+      success: '#22C55E',
+      error: '#EF4444',
+      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
+    },
+  },
+  Shadows: { card: {} },
+  Layout: { cardRadius: 16 },
+  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
+}));
+
+// Override the global Clerk mock so useSignIn is a proper jest.fn() for per-test control
+jest.mock('@clerk/clerk-expo', () => ({
+  ...jest.requireActual('@clerk/clerk-expo'),
+  useSignIn: jest.fn(),
+  useSSO: jest.fn(() => ({ startSSOFlow: jest.fn() })),
+}));
+
+// Mock native modules used by this screen's dependency tree
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock('expo-auth-session', () => ({
+  makeRedirectUri: jest.fn(() => 'myapp://redirect'),
+}));
+
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: jest.fn(),
+  warmUpAsync: jest.fn(),
+  coolDownAsync: jest.fn(),
+}));
+
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => children,
+    Svg: ({ children }: { children: React.ReactNode }) => children,
+    Path: () => null,
+    Circle: () => null,
+    G: () => null,
+  };
+});
+
+// Override the global Clerk mock for per-test control
+const mockSetActive = jest.fn();
+const mockSignInCreate = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useSignIn as jest.Mock).mockReturnValue({
+    signIn: { create: mockSignInCreate },
+    isLoaded: true,
+    setActive: mockSetActive,
+  });
+});
+
+// Helper: the screen has both a title "Sign In" and a button labeled "Sign In".
+// getAllByText returns them in DOM order; the last one is the button inside the form.
+function pressSignInButton() {
+  const allSignIn = screen.getAllByText('Sign In');
+  // The button is the last match (rendered after the title)
+  fireEvent.press(allSignIn[allSignIn.length - 1]);
+}
+
+describe('SignInScreen', () => {
+  it('renders email input, password input, and sign-in button', () => {
+    renderWithProviders(<SignInScreen />);
+
+    expect(screen.getByPlaceholderText('Enter your email address')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Enter your password')).toBeTruthy();
+    // Both the page title and the button say "Sign In"
+    expect(screen.getAllByText('Sign In').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('updates email input value when text is changed', () => {
+    renderWithProviders(<SignInScreen />);
+
+    const emailInput = screen.getByPlaceholderText('Enter your email address');
+    fireEvent.changeText(emailInput, 'test@example.com');
+
+    expect(emailInput.props.value).toBe('test@example.com');
+  });
+
+  it('updates password input value when text is changed', () => {
+    renderWithProviders(<SignInScreen />);
+
+    const passwordInput = screen.getByPlaceholderText('Enter your password');
+    fireEvent.changeText(passwordInput, 'secret123');
+
+    expect(passwordInput.props.value).toBe('secret123');
+  });
+
+  it('calls signIn.create with email and password on sign-in press', async () => {
+    mockSignInCreate.mockResolvedValueOnce({
+      status: 'needs_identifier',
+    });
+
+    renderWithProviders(<SignInScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'user@test.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'mypassword');
+    pressSignInButton();
+
+    await waitFor(() => {
+      expect(mockSignInCreate).toHaveBeenCalledWith({
+        identifier: 'user@test.com',
+        password: 'mypassword',
+      });
+    });
+  });
+
+  it('calls setActive when sign-in returns complete status', async () => {
+    mockSignInCreate.mockResolvedValueOnce({
+      status: 'complete',
+      createdSessionId: 'sess_123',
+    });
+
+    renderWithProviders(<SignInScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'user@test.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'mypassword');
+    pressSignInButton();
+
+    await waitFor(() => {
+      expect(mockSetActive).toHaveBeenCalledWith({ session: 'sess_123' });
+    });
+  });
+
+  it('shows an error message when sign-in throws a Clerk error', async () => {
+    const clerkError = {
+      errors: [{ longMessage: 'Invalid credentials' }],
+    };
+    mockSignInCreate.mockRejectedValueOnce(clerkError);
+
+    renderWithProviders(<SignInScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'user@test.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'wrongpassword');
+    pressSignInButton();
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid credentials')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/__tests__/screens/sign-in.test.tsx
+++ b/frontend/__tests__/screens/sign-in.test.tsx
@@ -6,7 +6,10 @@ import SignInScreen from '@/app/(auth)/sign-in';
 
 // Override the global Clerk mock so useSignIn is a proper jest.fn() for per-test control
 jest.mock('@clerk/clerk-expo', () => ({
-  useAuth: jest.fn(() => ({ isSignedIn: true, getToken: jest.fn().mockResolvedValue('mock-token') })),
+  useAuth: jest.fn(() => ({
+    isSignedIn: true,
+    getToken: jest.fn().mockResolvedValue('mock-token'),
+  })),
   useUser: jest.fn(() => ({
     user: {
       id: 'test-user-id',
@@ -18,7 +21,11 @@ jest.mock('@clerk/clerk-expo', () => ({
     isLoaded: true,
   })),
   useSignIn: jest.fn(),
-  useSignUp: jest.fn(() => ({ signUp: { create: jest.fn() }, isLoaded: true, setActive: jest.fn() })),
+  useSignUp: jest.fn(() => ({
+    signUp: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  })),
   useSSO: jest.fn(() => ({ startSSOFlow: jest.fn() })),
   useClerk: jest.fn(() => ({ signOut: jest.fn() })),
   ClerkProvider: ({ children }: { children: unknown }) => children,
@@ -168,7 +175,10 @@ describe('SignInScreen', () => {
 
     renderSignIn();
 
-    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'test@example.com');
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Enter your email address'),
+      'test@example.com'
+    );
     fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'password123');
     pressSignInButton();
 
@@ -184,7 +194,10 @@ describe('SignInScreen', () => {
 
     renderSignIn();
 
-    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'test@example.com');
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Enter your email address'),
+      'test@example.com'
+    );
     fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'password123');
     await act(async () => {
       pressSignInButton();

--- a/frontend/__tests__/screens/sign-in.test.tsx
+++ b/frontend/__tests__/screens/sign-in.test.tsx
@@ -6,9 +6,22 @@ import SignInScreen from '@/app/(auth)/sign-in';
 
 // Override the global Clerk mock so useSignIn is a proper jest.fn() for per-test control
 jest.mock('@clerk/clerk-expo', () => ({
-  ...jest.requireActual('@clerk/clerk-expo'),
+  useAuth: jest.fn(() => ({ isSignedIn: true, getToken: jest.fn().mockResolvedValue('mock-token') })),
+  useUser: jest.fn(() => ({
+    user: {
+      id: 'test-user-id',
+      firstName: 'Test',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
+    },
+    isLoaded: true,
+  })),
   useSignIn: jest.fn(),
+  useSignUp: jest.fn(() => ({ signUp: { create: jest.fn() }, isLoaded: true, setActive: jest.fn() })),
   useSSO: jest.fn(() => ({ startSSOFlow: jest.fn() })),
+  useClerk: jest.fn(() => ({ signOut: jest.fn() })),
+  ClerkProvider: ({ children }: { children: unknown }) => children,
 }));
 
 // Mock native modules used by this screen's dependency tree

--- a/frontend/__tests__/screens/sign-in.test.tsx
+++ b/frontend/__tests__/screens/sign-in.test.tsx
@@ -1,31 +1,8 @@
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import { useSignIn } from '@clerk/clerk-expo';
 import { renderWithProviders } from '@/__tests__/test-utils';
 import SignInScreen from '@/app/(auth)/sign-in';
-
-// theme.ts calls Platform.select at module-init level; mock the whole module to
-// avoid relying on the Platform mock being established before module evaluation.
-jest.mock('@/constants/theme', () => ({
-  Colors: {
-    light: {
-      text: '#111827',
-      textMuted: '#6B7280',
-      background: '#F8FAFC',
-      surface: '#FFFFFF',
-      primary: '#2B9D8F',
-      primaryDark: '#1F6D63',
-      tint: '#2B9D8F',
-      secondary: '#FFB74D',
-      success: '#22C55E',
-      error: '#EF4444',
-      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
-    },
-  },
-  Shadows: { card: {} },
-  Layout: { cardRadius: 16 },
-  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
-}));
 
 // Override the global Clerk mock so useSignIn is a proper jest.fn() for per-test control
 jest.mock('@clerk/clerk-expo', () => ({
@@ -65,15 +42,20 @@ jest.mock('react-native-svg', () => {
 // Override the global Clerk mock for per-test control
 const mockSetActive = jest.fn();
 const mockSignInCreate = jest.fn();
+const mockPrepareSecondFactor = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
   (useSignIn as jest.Mock).mockReturnValue({
-    signIn: { create: mockSignInCreate },
+    signIn: { create: mockSignInCreate, prepareSecondFactor: mockPrepareSecondFactor },
     isLoaded: true,
     setActive: mockSetActive,
   });
 });
+
+function renderSignIn() {
+  return renderWithProviders(<SignInScreen />);
+}
 
 // Helper: the screen has both a title "Sign In" and a button labeled "Sign In".
 // getAllByText returns them in DOM order; the last one is the button inside the form.
@@ -161,6 +143,42 @@ describe('SignInScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Invalid credentials')).toBeTruthy();
+    });
+  });
+
+  it('does not call signIn.create when Clerk is not loaded', async () => {
+    (useSignIn as jest.Mock).mockReturnValue({
+      signIn: { create: mockSignInCreate, prepareSecondFactor: mockPrepareSecondFactor },
+      isLoaded: false,
+      setActive: mockSetActive,
+    });
+
+    renderSignIn();
+
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'test@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'password123');
+    pressSignInButton();
+
+    expect(mockSignInCreate).not.toHaveBeenCalled();
+  });
+
+  it('shows verification screen after needs_second_factor response', async () => {
+    mockSignInCreate.mockResolvedValueOnce({
+      status: 'needs_second_factor',
+      supportedSecondFactors: [{ strategy: 'email_code', emailAddressId: 'ead_123' }],
+    });
+    mockPrepareSecondFactor.mockResolvedValueOnce({});
+
+    renderSignIn();
+
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your email address'), 'test@example.com');
+    fireEvent.changeText(screen.getByPlaceholderText('Enter your password'), 'password123');
+    await act(async () => {
+      pressSignInButton();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/verify your email/i)).toBeTruthy();
     });
   });
 });

--- a/frontend/__tests__/test-utils.tsx
+++ b/frontend/__tests__/test-utils.tsx
@@ -1,0 +1,30 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, type RenderOptions } from '@testing-library/react-native';
+import React from 'react';
+
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+export function createWrapper() {
+  const queryClient = createQueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    options
+  );
+}

--- a/frontend/__tests__/test-utils.tsx
+++ b/frontend/__tests__/test-utils.tsx
@@ -23,8 +23,5 @@ export function renderWithProviders(
   options?: Omit<RenderOptions, 'wrapper'>
 ) {
   const queryClient = createQueryClient();
-  return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
-    options
-  );
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>, options);
 }

--- a/frontend/__tests__/utils/healthScore.test.ts
+++ b/frontend/__tests__/utils/healthScore.test.ts
@@ -107,34 +107,54 @@ describe('calculateHealthScore – nutrition score', () => {
 
 describe('calculateHealthScore – sleep score', () => {
   it('returns 100 for 8 hours sleep (23:00 to 07:00)', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: '23:00',
-      wake_up_time: '07:00',
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: '23:00',
+        wake_up_time: '07:00',
+      },
+      false
+    );
     expect(result.sleep.score).toBe(100);
   });
 
   it('returns 75 for 6 hours sleep (01:00 to 07:00)', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: '01:00',
-      wake_up_time: '07:00',
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: '01:00',
+        wake_up_time: '07:00',
+      },
+      false
+    );
     expect(result.sleep.score).toBe(75);
   });
 
   it('returns 70 when sleep_time is null', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: null,
-      wake_up_time: '07:00',
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: null,
+        wake_up_time: '07:00',
+      },
+      false
+    );
     expect(result.sleep.score).toBe(70);
   });
 
   it('returns 70 when wake_up_time is null', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: '23:00',
-      wake_up_time: null,
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: '23:00',
+        wake_up_time: null,
+      },
+      false
+    );
     expect(result.sleep.score).toBe(70);
   });
 
@@ -144,26 +164,41 @@ describe('calculateHealthScore – sleep score', () => {
   });
 
   it('returns 100 for exactly 7 hours (00:00 to 07:00)', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: '00:00',
-      wake_up_time: '07:00',
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: '00:00',
+        wake_up_time: '07:00',
+      },
+      false
+    );
     expect(result.sleep.score).toBe(100);
   });
 
   it('returns 100 for exactly 9 hours (22:00 to 07:00)', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: '22:00',
-      wake_up_time: '07:00',
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: '22:00',
+        wake_up_time: '07:00',
+      },
+      false
+    );
     expect(result.sleep.score).toBe(100);
   });
 
   it('returns 50 for less than 6 hours sleep (03:00 to 07:00 = 4h)', () => {
-    const result = calculateHealthScore(undefined, undefined, {
-      sleep_time: '03:00',
-      wake_up_time: '07:00',
-    }, false);
+    const result = calculateHealthScore(
+      undefined,
+      undefined,
+      {
+        sleep_time: '03:00',
+        wake_up_time: '07:00',
+      },
+      false
+    );
     expect(result.sleep.score).toBe(50);
   });
 });
@@ -222,9 +257,18 @@ describe('calculateHealthScore – exercise score', () => {
 describe('calculateHealthScore – status labels', () => {
   it('returns "Excellent" for score >= 90', () => {
     // Perfect everything → overall 100
-    const plan = makeDailyPlan(2000, 150, 250, 65, { category: 'Cardio', duration_minutes: 30, calories_burned: 300 });
+    const plan = makeDailyPlan(2000, 150, 250, 65, {
+      category: 'Cardio',
+      duration_minutes: 30,
+      calories_burned: 300,
+    });
     const targets = makeDri(2000, 150, 250, 65);
-    const result = calculateHealthScore(plan, targets, { sleep_time: '23:00', wake_up_time: '07:00' }, true);
+    const result = calculateHealthScore(
+      plan,
+      targets,
+      { sleep_time: '23:00', wake_up_time: '07:00' },
+      true
+    );
     expect(result.overall).toBe(100);
     expect(result.nutrition.status).toBe('Excellent');
     expect(result.exercise.status).toBe('Excellent');
@@ -235,7 +279,12 @@ describe('calculateHealthScore – status labels', () => {
     // nutrition=100, exercise=0 (hasPlan=false), sleep=100 → overall = 40+0+30 = 70
     const plan = makeDailyPlan(2000, 150, 250, 65);
     const targets = makeDri(2000, 150, 250, 65);
-    const result = calculateHealthScore(plan, targets, { sleep_time: '23:00', wake_up_time: '07:00' }, false);
+    const result = calculateHealthScore(
+      plan,
+      targets,
+      { sleep_time: '23:00', wake_up_time: '07:00' },
+      false
+    );
     expect(result.overall).toBe(70);
     expect(result.nutrition.status).toBe('Excellent');
     expect(result.exercise.status).toBe('Needs Work');
@@ -247,12 +296,17 @@ describe('calculateHealthScore – status labels', () => {
     // Let's use nutrition=100, exercise=0, sleep=75 → 40 + 0 + 22.5 = 62.5 → 63
     const plan = makeDailyPlan(2000, 150, 250, 65);
     const targets = makeDri(2000, 150, 250, 65);
-    const result = calculateHealthScore(plan, targets, { sleep_time: '01:00', wake_up_time: '07:00' }, false);
+    const result = calculateHealthScore(
+      plan,
+      targets,
+      { sleep_time: '01:00', wake_up_time: '07:00' },
+      false
+    );
     // nutrition=100, exercise=0, sleep=75 → 40 + 0 + 22.5 = 62.5 → 63
     expect(result.overall).toBe(63);
     expect(result.nutrition.status).toBe('Excellent'); // 100
     expect(result.exercise.status).toBe('Needs Work'); // 0
-    expect(result.sleep.status).toBe('Good');           // 75
+    expect(result.sleep.status).toBe('Good'); // 75
   });
 
   it('returns "Needs Work" for score < 50', () => {
@@ -272,9 +326,18 @@ describe('calculateHealthScore – status labels', () => {
 describe('calculateHealthScore – overall weighted formula', () => {
   it('computes overall as round(nutrition*0.4 + exercise*0.3 + sleep*0.3)', () => {
     // nutrition=100, exercise=100, sleep=75 → round(40 + 30 + 22.5) = 93
-    const plan = makeDailyPlan(2000, 150, 250, 65, { category: 'Cardio', duration_minutes: 30, calories_burned: 300 });
+    const plan = makeDailyPlan(2000, 150, 250, 65, {
+      category: 'Cardio',
+      duration_minutes: 30,
+      calories_burned: 300,
+    });
     const targets = makeDri(2000, 150, 250, 65);
-    const result = calculateHealthScore(plan, targets, { sleep_time: '01:00', wake_up_time: '07:00' }, true);
+    const result = calculateHealthScore(
+      plan,
+      targets,
+      { sleep_time: '01:00', wake_up_time: '07:00' },
+      true
+    );
     expect(result.overall).toBe(93);
   });
 

--- a/frontend/__tests__/utils/healthScore.test.ts
+++ b/frontend/__tests__/utils/healthScore.test.ts
@@ -1,0 +1,285 @@
+import type { DailyMealPlanOutput, DriOutput } from '@/api/types.gen';
+import { calculateHealthScore } from '@/utils/healthScore';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeDri(calories: number, protein: number, carbs: number, fat: number): DriOutput {
+  return {
+    calories: { min: 0, target: calories, max: calories * 1.2 },
+    protein: { min: 0, target: protein, max: protein * 1.2 },
+    carbohydrates: { min: 0, target: carbs, max: carbs * 1.2 },
+    fat: { min: 0, target: fat, max: fat * 1.2 },
+  };
+}
+
+function makeDailyPlan(
+  calories: number,
+  protein: number,
+  carbs: number,
+  fat: number,
+  exercise?: DailyMealPlanOutput['exercise']
+): DailyMealPlanOutput {
+  return {
+    day: 'Monday',
+    slots: [],
+    total_calories: calories,
+    total_protein: protein,
+    total_carbs: carbs,
+    total_fat: fat,
+    exercise: exercise ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// hasPlan: false – exercise always 0
+// ---------------------------------------------------------------------------
+
+describe('calculateHealthScore – hasPlan: false', () => {
+  it('returns exercise score 0 when hasPlan is false', () => {
+    const result = calculateHealthScore(undefined, undefined, null, false);
+    expect(result.exercise.score).toBe(0);
+  });
+
+  it('returns nutrition score 0 when todayPlan and targets are both undefined', () => {
+    const result = calculateHealthScore(undefined, undefined, null, false);
+    expect(result.nutrition.score).toBe(0);
+  });
+
+  it('returns default sleep score 70 when user is null', () => {
+    const result = calculateHealthScore(undefined, undefined, null, false);
+    expect(result.sleep.score).toBe(70);
+  });
+
+  it('calculates overall as weighted sum: 0*0.4 + 0*0.3 + 70*0.3 = 21', () => {
+    const result = calculateHealthScore(undefined, undefined, null, false);
+    expect(result.overall).toBe(21);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nutrition score
+// ---------------------------------------------------------------------------
+
+describe('calculateHealthScore – nutrition score', () => {
+  it('returns 100 when all actuals equal targets exactly', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65);
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, null, true);
+    expect(result.nutrition.score).toBe(100);
+  });
+
+  it('returns 0 when todayPlan is undefined', () => {
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(undefined, targets, null, true);
+    expect(result.nutrition.score).toBe(0);
+  });
+
+  it('returns 0 when targets are undefined', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, undefined, null, true);
+    expect(result.nutrition.score).toBe(0);
+  });
+
+  it('clamps individual macro adherence to 0 (no negative scores)', () => {
+    // actual = 0, target = 2000 → adherence = 100 - (2000/2000)*100 = 0
+    // All macros at 0 → nutrition score = 0
+    const plan = makeDailyPlan(0, 0, 0, 0);
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, null, true);
+    expect(result.nutrition.score).toBe(0);
+  });
+
+  it('clamps individual macro adherence to 100 (no over-100 scores)', () => {
+    // actual = 2x target → adherence = 100 - 100 = 0 → score still 0
+    // actual = 1.5x target for all → adherence = 100 - 50 = 50 → nutrition score = 50
+    const plan = makeDailyPlan(3000, 225, 375, 97.5);
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, null, true);
+    expect(result.nutrition.score).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sleep score
+// ---------------------------------------------------------------------------
+
+describe('calculateHealthScore – sleep score', () => {
+  it('returns 100 for 8 hours sleep (23:00 to 07:00)', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: '23:00',
+      wake_up_time: '07:00',
+    }, false);
+    expect(result.sleep.score).toBe(100);
+  });
+
+  it('returns 75 for 6 hours sleep (01:00 to 07:00)', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: '01:00',
+      wake_up_time: '07:00',
+    }, false);
+    expect(result.sleep.score).toBe(75);
+  });
+
+  it('returns 70 when sleep_time is null', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: null,
+      wake_up_time: '07:00',
+    }, false);
+    expect(result.sleep.score).toBe(70);
+  });
+
+  it('returns 70 when wake_up_time is null', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: '23:00',
+      wake_up_time: null,
+    }, false);
+    expect(result.sleep.score).toBe(70);
+  });
+
+  it('returns 70 when user is undefined', () => {
+    const result = calculateHealthScore(undefined, undefined, undefined, false);
+    expect(result.sleep.score).toBe(70);
+  });
+
+  it('returns 100 for exactly 7 hours (00:00 to 07:00)', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: '00:00',
+      wake_up_time: '07:00',
+    }, false);
+    expect(result.sleep.score).toBe(100);
+  });
+
+  it('returns 100 for exactly 9 hours (22:00 to 07:00)', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: '22:00',
+      wake_up_time: '07:00',
+    }, false);
+    expect(result.sleep.score).toBe(100);
+  });
+
+  it('returns 50 for less than 6 hours sleep (03:00 to 07:00 = 4h)', () => {
+    const result = calculateHealthScore(undefined, undefined, {
+      sleep_time: '03:00',
+      wake_up_time: '07:00',
+    }, false);
+    expect(result.sleep.score).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exercise score
+// ---------------------------------------------------------------------------
+
+describe('calculateHealthScore – exercise score', () => {
+  it('returns 100 when hasPlan is true and calories_burned > 0', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65, {
+      category: 'Cardio',
+      duration_minutes: 30,
+      calories_burned: 300,
+    });
+    const result = calculateHealthScore(plan, undefined, null, true);
+    expect(result.exercise.score).toBe(100);
+  });
+
+  it('returns 85 when hasPlan is true and exercise exists but no calories_burned', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65, {
+      category: 'Weight Lifting',
+      duration_minutes: 45,
+    });
+    const result = calculateHealthScore(plan, undefined, null, true);
+    expect(result.exercise.score).toBe(85);
+  });
+
+  it('returns 30 when hasPlan is true but exercise is null', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65, null);
+    const result = calculateHealthScore(plan, undefined, null, true);
+    expect(result.exercise.score).toBe(30);
+  });
+
+  it('returns 30 when hasPlan is true and todayPlan has no exercise field', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, undefined, null, true);
+    expect(result.exercise.score).toBe(30);
+  });
+
+  it('returns 0 when hasPlan is false regardless of exercise data', () => {
+    const plan = makeDailyPlan(2000, 150, 250, 65, {
+      category: 'Cardio',
+      duration_minutes: 30,
+      calories_burned: 500,
+    });
+    const result = calculateHealthScore(plan, undefined, null, false);
+    expect(result.exercise.score).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Status labels
+// ---------------------------------------------------------------------------
+
+describe('calculateHealthScore – status labels', () => {
+  it('returns "Excellent" for score >= 90', () => {
+    // Perfect everything → overall 100
+    const plan = makeDailyPlan(2000, 150, 250, 65, { category: 'Cardio', duration_minutes: 30, calories_burned: 300 });
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, { sleep_time: '23:00', wake_up_time: '07:00' }, true);
+    expect(result.overall).toBe(100);
+    expect(result.nutrition.status).toBe('Excellent');
+    expect(result.exercise.status).toBe('Excellent');
+    expect(result.sleep.status).toBe('Excellent');
+  });
+
+  it('returns "Good" for score >= 70 and < 90', () => {
+    // nutrition=100, exercise=0 (hasPlan=false), sleep=100 → overall = 40+0+30 = 70
+    const plan = makeDailyPlan(2000, 150, 250, 65);
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, { sleep_time: '23:00', wake_up_time: '07:00' }, false);
+    expect(result.overall).toBe(70);
+    expect(result.nutrition.status).toBe('Excellent');
+    expect(result.exercise.status).toBe('Needs Work');
+    expect(result.sleep.status).toBe('Excellent');
+  });
+
+  it('returns "Fair" for score >= 50 and < 70', () => {
+    // nutrition=0, exercise=85, sleep=50 → 0*0.4 + 85*0.3 + 50*0.3 = 0 + 25.5 + 15 = 40.5 → 41...
+    // Let's use nutrition=100, exercise=0, sleep=75 → 40 + 0 + 22.5 = 62.5 → 63
+    const plan = makeDailyPlan(2000, 150, 250, 65);
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, { sleep_time: '01:00', wake_up_time: '07:00' }, false);
+    // nutrition=100, exercise=0, sleep=75 → 40 + 0 + 22.5 = 62.5 → 63
+    expect(result.overall).toBe(63);
+    expect(result.nutrition.status).toBe('Excellent'); // 100
+    expect(result.exercise.status).toBe('Needs Work'); // 0
+    expect(result.sleep.status).toBe('Good');           // 75
+  });
+
+  it('returns "Needs Work" for score < 50', () => {
+    // no plan, no targets, no user → overall = 21
+    const result = calculateHealthScore(undefined, undefined, null, false);
+    expect(result.overall).toBe(21);
+    expect(result.nutrition.status).toBe('Needs Work');
+    expect(result.exercise.status).toBe('Needs Work');
+    expect(result.sleep.status).toBe('Good'); // 70
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Overall weighted formula
+// ---------------------------------------------------------------------------
+
+describe('calculateHealthScore – overall weighted formula', () => {
+  it('computes overall as round(nutrition*0.4 + exercise*0.3 + sleep*0.3)', () => {
+    // nutrition=100, exercise=100, sleep=75 → round(40 + 30 + 22.5) = 93
+    const plan = makeDailyPlan(2000, 150, 250, 65, { category: 'Cardio', duration_minutes: 30, calories_burned: 300 });
+    const targets = makeDri(2000, 150, 250, 65);
+    const result = calculateHealthScore(plan, targets, { sleep_time: '01:00', wake_up_time: '07:00' }, true);
+    expect(result.overall).toBe(93);
+  });
+
+  it('computes overall = 21 for all-zero scenario (nutrition=0, exercise=0, sleep=70)', () => {
+    const result = calculateHealthScore(undefined, undefined, null, false);
+    expect(result.overall).toBe(Math.round(0 * 0.4 + 0 * 0.3 + 70 * 0.3));
+  });
+});

--- a/frontend/__tests__/utils/mealPlanMapper.test.ts
+++ b/frontend/__tests__/utils/mealPlanMapper.test.ts
@@ -1,0 +1,410 @@
+import type {
+  DailyMealPlanOutput,
+  MealSlotTargetOutput,
+  Recipe,
+  WeeklyMealPlanOutput,
+} from '@/api/types.gen';
+import type { WeeklyScheduleItem } from '@/types/schedule';
+import {
+  addItemToRawPlan,
+  displayTimeToApiTime,
+  mapDailyPlanToScheduleItems,
+  removeItemFromRawPlan,
+} from '@/utils/mealPlanMapper';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeRecipe(id: string, title: string, calories = 400, protein = 30, carbs = 50, fat = 10): Recipe {
+  return {
+    id,
+    title,
+    nutrients: { calories, protein, carbohydrates: carbs, fat },
+    preparation_time_minutes: 20,
+  };
+}
+
+function makeSlot(
+  slotName: MealSlotTargetOutput['slot_name'],
+  time: string,
+  calories: number,
+  recipe?: Recipe
+): MealSlotTargetOutput {
+  return {
+    slot_name: slotName,
+    time,
+    calories,
+    protein: recipe?.nutrients.protein ?? 0,
+    carbohydrates: recipe?.nutrients.carbohydrates ?? 0,
+    fat: recipe?.nutrients.fat ?? 0,
+    plan: recipe ? { main_recipe: recipe, alternatives: [] } : null,
+  };
+}
+
+function makeDailyPlan(slots: MealSlotTargetOutput[], exercise?: DailyMealPlanOutput['exercise']): DailyMealPlanOutput {
+  const total_calories = slots.reduce((sum, s) => sum + (s.plan?.main_recipe?.nutrients.calories ?? s.calories), 0);
+  return {
+    day: 'Monday',
+    slots,
+    exercise: exercise ?? null,
+    total_calories,
+    total_protein: 0,
+    total_carbs: 0,
+    total_fat: 0,
+  };
+}
+
+function makeWeeklyPlan(dailyPlan: DailyMealPlanOutput): WeeklyMealPlanOutput {
+  return {
+    daily_plans: [dailyPlan],
+    total_weekly_calories: dailyPlan.total_calories,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// displayTimeToApiTime
+// ---------------------------------------------------------------------------
+
+describe('displayTimeToApiTime', () => {
+  it('converts "7:30 AM" to "07:30:00"', () => {
+    expect(displayTimeToApiTime('7:30 AM')).toBe('07:30:00');
+  });
+
+  it('converts "12:00 PM" to "12:00:00"', () => {
+    expect(displayTimeToApiTime('12:00 PM')).toBe('12:00:00');
+  });
+
+  it('converts "11:00 PM" to "23:00:00"', () => {
+    expect(displayTimeToApiTime('11:00 PM')).toBe('23:00:00');
+  });
+
+  it('converts "12:00 AM" to "00:00:00"', () => {
+    expect(displayTimeToApiTime('12:00 AM')).toBe('00:00:00');
+  });
+
+  it('converts "1:00 PM" to "13:00:00"', () => {
+    expect(displayTimeToApiTime('1:00 PM')).toBe('13:00:00');
+  });
+
+  it('converts "6:00 AM" to "06:00:00"', () => {
+    expect(displayTimeToApiTime('6:00 AM')).toBe('06:00:00');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapDailyPlanToScheduleItems
+// ---------------------------------------------------------------------------
+
+describe('mapDailyPlanToScheduleItems', () => {
+  it('returns an array with one item per meal slot', () => {
+    const recipe = makeRecipe('r1', 'Oatmeal');
+    const slot = makeSlot('Breakfast', '08:00:00', 400, recipe);
+    const plan = makeDailyPlan([slot]);
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe('meal');
+  });
+
+  it('returns empty array when plan has no slots and no exercise', () => {
+    const plan = makeDailyPlan([]);
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items).toHaveLength(0);
+  });
+
+  it('includes exercise item when plan has exercise', () => {
+    const plan = makeDailyPlan([], {
+      category: 'Cardio',
+      duration_minutes: 30,
+      time: '06:00:00',
+      calories_burned: 250,
+    });
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe('workout');
+    expect(items[0].id).toBe('exercise-Cardio');
+  });
+
+  it('uses recipe title as item title when recipe is present', () => {
+    const recipe = makeRecipe('r1', 'Avocado Toast');
+    const slot = makeSlot('Breakfast', '08:00:00', 400, recipe);
+    const plan = makeDailyPlan([slot]);
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items[0].title).toBe('Avocado Toast');
+  });
+
+  it('falls back to slot_name when no recipe', () => {
+    const slot = makeSlot('Lunch', '12:00:00', 500);
+    const plan = makeDailyPlan([slot]);
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items[0].title).toBe('Lunch');
+  });
+
+  it('sorts items by time ascending', () => {
+    const recipe1 = makeRecipe('r1', 'Dinner');
+    const recipe2 = makeRecipe('r2', 'Breakfast');
+    const dinnerSlot = makeSlot('Dinner', '19:00:00', 600, recipe1);
+    const breakfastSlot = makeSlot('Breakfast', '08:00:00', 400, recipe2);
+    const plan = makeDailyPlan([dinnerSlot, breakfastSlot]);
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items[0].title).toBe('Breakfast');
+    expect(items[1].title).toBe('Dinner');
+  });
+
+  it('places exercise between meals when time is between them', () => {
+    const recipe1 = makeRecipe('r1', 'Morning Meal');
+    const recipe2 = makeRecipe('r2', 'Evening Meal');
+    const morningSlot = makeSlot('Breakfast', '08:00:00', 400, recipe1);
+    const eveningSlot = makeSlot('Dinner', '19:00:00', 600, recipe2);
+    const plan = makeDailyPlan([morningSlot, eveningSlot], {
+      category: 'Cardio',
+      duration_minutes: 30,
+      time: '12:00:00',
+      calories_burned: 300,
+    });
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items).toHaveLength(3);
+    expect(items[0].title).toBe('Morning Meal');
+    expect(items[1].type).toBe('workout');
+    expect(items[2].title).toBe('Evening Meal');
+  });
+
+  it('uses recipe id as the item id', () => {
+    const recipe = makeRecipe('recipe-42', 'Pasta');
+    const slot = makeSlot('Dinner', '19:00:00', 600, recipe);
+    const plan = makeDailyPlan([slot]);
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items[0].id).toBe('recipe-42');
+  });
+
+  it('maps exercise calories_burned to item calories', () => {
+    const plan = makeDailyPlan([], {
+      category: 'Weight Lifting',
+      duration_minutes: 45,
+      calories_burned: 180,
+    });
+    const items = mapDailyPlanToScheduleItems(plan);
+    expect(items[0].calories).toBe(180);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeItemFromRawPlan
+// ---------------------------------------------------------------------------
+
+describe('removeItemFromRawPlan', () => {
+  it('removes the meal slot with the matching recipe id', () => {
+    const recipe1 = makeRecipe('recipe-1', 'Oatmeal', 350, 10, 60, 8);
+    const recipe2 = makeRecipe('recipe-2', 'Salad', 200, 5, 30, 5);
+    const slot1 = makeSlot('Breakfast', '08:00:00', 350, recipe1);
+    const slot2 = makeSlot('Lunch', '12:00:00', 200, recipe2);
+    const dailyPlan = makeDailyPlan([slot1, slot2]);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+
+    const result = removeItemFromRawPlan(weeklyPlan, 'Monday', 'recipe-1');
+
+    const updatedDay = result.daily_plans[0];
+    expect(updatedDay.slots).toHaveLength(1);
+    expect(updatedDay.slots[0].plan?.main_recipe?.id).toBe('recipe-2');
+  });
+
+  it('recalculates total_calories after removing a meal slot', () => {
+    const recipe1 = makeRecipe('recipe-1', 'Oatmeal', 350, 10, 60, 8);
+    const recipe2 = makeRecipe('recipe-2', 'Salad', 200, 5, 30, 5);
+    const slot1 = makeSlot('Breakfast', '08:00:00', 350, recipe1);
+    const slot2 = makeSlot('Lunch', '12:00:00', 200, recipe2);
+    const dailyPlan = makeDailyPlan([slot1, slot2]);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+
+    const result = removeItemFromRawPlan(weeklyPlan, 'Monday', 'recipe-1');
+
+    // remaining: recipe2 = 200 cal
+    expect(result.daily_plans[0].total_calories).toBe(200);
+    expect(result.total_weekly_calories).toBe(200);
+  });
+
+  it('removes exercise when itemId starts with "exercise-"', () => {
+    const exercise = { category: 'Cardio' as const, duration_minutes: 30, calories_burned: 300 };
+    const dailyPlan = makeDailyPlan([], exercise);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+
+    const result = removeItemFromRawPlan(weeklyPlan, 'Monday', 'exercise-Cardio');
+
+    expect(result.daily_plans[0].exercise).toBeNull();
+  });
+
+  it('does not modify other days', () => {
+    const recipe = makeRecipe('r1', 'Oatmeal', 400, 10, 60, 8);
+    const slot = makeSlot('Breakfast', '08:00:00', 400, recipe);
+    const mondayPlan = makeDailyPlan([slot]);
+    const tuesdayPlan: DailyMealPlanOutput = {
+      day: 'Tuesday',
+      slots: [makeSlot('Lunch', '12:00:00', 500)],
+      exercise: null,
+      total_calories: 500,
+      total_protein: 0,
+      total_carbs: 0,
+      total_fat: 0,
+    };
+    const weeklyPlan: WeeklyMealPlanOutput = {
+      daily_plans: [mondayPlan, tuesdayPlan],
+      total_weekly_calories: 900,
+    };
+
+    const result = removeItemFromRawPlan(weeklyPlan, 'Monday', 'r1');
+
+    // Tuesday should be untouched
+    expect(result.daily_plans[1].slots).toHaveLength(1);
+    expect(result.daily_plans[1].total_calories).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addItemToRawPlan
+// ---------------------------------------------------------------------------
+
+describe('addItemToRawPlan', () => {
+  it('adds a meal item to the correct day', () => {
+    const dailyPlan = makeDailyPlan([]);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+
+    const newItem: WeeklyScheduleItem = {
+      id: 'recipe-99',
+      time: '8:00 AM',
+      title: 'New Breakfast',
+      duration: '20 min',
+      type: 'meal',
+      calories: 400,
+    };
+
+    const result = addItemToRawPlan(weeklyPlan, 'Monday', newItem);
+
+    expect(result.daily_plans[0].slots).toHaveLength(1);
+    expect(result.daily_plans[0].slots[0].slot_name).toBe('Breakfast');
+  });
+
+  it('adds a workout item to the correct day', () => {
+    const dailyPlan = makeDailyPlan([]);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+
+    const workoutItem: WeeklyScheduleItem = {
+      id: 'exercise-Cardio',
+      time: '6:00 AM',
+      title: 'Cardio',
+      duration: '30 min',
+      type: 'workout',
+      calories: 300,
+      workoutType: 'Cardio',
+    };
+
+    const result = addItemToRawPlan(weeklyPlan, 'Monday', workoutItem);
+
+    expect(result.daily_plans[0].exercise).not.toBeNull();
+    expect(result.daily_plans[0].exercise?.category).toBe('Cardio');
+    expect(result.daily_plans[0].exercise?.duration_minutes).toBe(30);
+    expect(result.daily_plans[0].exercise?.calories_burned).toBe(300);
+  });
+
+  it('recalculates total_calories after adding a meal item', () => {
+    const recipe = makeRecipe('r1', 'Existing', 300, 10, 40, 8);
+    const slot = makeSlot('Breakfast', '08:00:00', 300, recipe);
+    const dailyPlan = makeDailyPlan([slot]);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+
+    const newItem: WeeklyScheduleItem = {
+      id: 'new-item',
+      time: '12:00 PM',
+      title: 'New Lunch',
+      duration: '30 min',
+      type: 'meal',
+      calories: 500,
+    };
+
+    const result = addItemToRawPlan(weeklyPlan, 'Monday', newItem);
+
+    // existing slot has no recipe (wait - it does), recipe1=300 + new slot=500 (no recipe, uses slot.calories)
+    // recalcDailyTotals: slot1 has recipe → 300, new slot has no recipe → slot.calories = 500
+    expect(result.daily_plans[0].total_calories).toBe(800);
+    expect(result.total_weekly_calories).toBe(800);
+  });
+
+  it('does not modify other days', () => {
+    const mondayPlan = makeDailyPlan([]);
+    const tuesdayPlan: DailyMealPlanOutput = {
+      day: 'Tuesday',
+      slots: [],
+      exercise: null,
+      total_calories: 0,
+      total_protein: 0,
+      total_carbs: 0,
+      total_fat: 0,
+    };
+    const weeklyPlan: WeeklyMealPlanOutput = {
+      daily_plans: [mondayPlan, tuesdayPlan],
+      total_weekly_calories: 0,
+    };
+
+    const newItem: WeeklyScheduleItem = {
+      id: 'r1',
+      time: '8:00 AM',
+      title: 'Breakfast',
+      duration: '20 min',
+      type: 'meal',
+      calories: 400,
+    };
+
+    const result = addItemToRawPlan(weeklyPlan, 'Monday', newItem);
+
+    expect(result.daily_plans[0].slots).toHaveLength(1);
+    expect(result.daily_plans[1].slots).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferSlotName (tested indirectly via addItemToRawPlan)
+// ---------------------------------------------------------------------------
+
+describe('inferSlotName (via addItemToRawPlan)', () => {
+  function getSlotName(time: string): string {
+    const dailyPlan = makeDailyPlan([]);
+    const weeklyPlan = makeWeeklyPlan(dailyPlan);
+    const item: WeeklyScheduleItem = {
+      id: 'test',
+      time,
+      title: 'Test',
+      duration: '20 min',
+      type: 'meal',
+      calories: 0,
+    };
+    const result = addItemToRawPlan(weeklyPlan, 'Monday', item);
+    return result.daily_plans[0].slots[0].slot_name;
+  }
+
+  it('assigns Breakfast for hour < 11 (7:30 AM → hour 7)', () => {
+    expect(getSlotName('7:30 AM')).toBe('Breakfast');
+  });
+
+  it('assigns Breakfast for hour 10 (10:00 AM)', () => {
+    expect(getSlotName('10:00 AM')).toBe('Breakfast');
+  });
+
+  it('assigns Lunch for hour 11 (11:00 AM)', () => {
+    expect(getSlotName('11:00 AM')).toBe('Lunch');
+  });
+
+  it('assigns Lunch for hour 12 (12:00 PM)', () => {
+    expect(getSlotName('12:00 PM')).toBe('Lunch');
+  });
+
+  it('assigns Lunch for hour 14 (2:00 PM)', () => {
+    expect(getSlotName('2:00 PM')).toBe('Lunch');
+  });
+
+  it('assigns Dinner for hour >= 15 (3:00 PM → hour 15)', () => {
+    expect(getSlotName('3:00 PM')).toBe('Dinner');
+  });
+
+  it('assigns Dinner for hour 19 (7:00 PM)', () => {
+    expect(getSlotName('7:00 PM')).toBe('Dinner');
+  });
+});

--- a/frontend/__tests__/utils/mealPlanMapper.test.ts
+++ b/frontend/__tests__/utils/mealPlanMapper.test.ts
@@ -16,7 +16,14 @@ import {
 // Fixture helpers
 // ---------------------------------------------------------------------------
 
-function makeRecipe(id: string, title: string, calories = 400, protein = 30, carbs = 50, fat = 10): Recipe {
+function makeRecipe(
+  id: string,
+  title: string,
+  calories = 400,
+  protein = 30,
+  carbs = 50,
+  fat = 10
+): Recipe {
   return {
     id,
     title,
@@ -42,8 +49,14 @@ function makeSlot(
   };
 }
 
-function makeDailyPlan(slots: MealSlotTargetOutput[], exercise?: DailyMealPlanOutput['exercise']): DailyMealPlanOutput {
-  const total_calories = slots.reduce((sum, s) => sum + (s.plan?.main_recipe?.nutrients.calories ?? s.calories), 0);
+function makeDailyPlan(
+  slots: MealSlotTargetOutput[],
+  exercise?: DailyMealPlanOutput['exercise']
+): DailyMealPlanOutput {
+  const total_calories = slots.reduce(
+    (sum, s) => sum + (s.plan?.main_recipe?.nutrients.calories ?? s.calories),
+    0
+  );
   return {
     day: 'Monday',
     slots,

--- a/frontend/__tests__/utils/units.test.ts
+++ b/frontend/__tests__/utils/units.test.ts
@@ -1,0 +1,144 @@
+import {
+  UNIT_CONVERSION,
+  cmToFeetAndInches,
+  cmToInches,
+  feetAndInchesToCm,
+  inchesToCm,
+  kgToLbs,
+  lbsToKg,
+} from '@/utils/units';
+
+describe('UNIT_CONVERSION constants', () => {
+  it('exposes LBS_TO_KG', () => {
+    expect(UNIT_CONVERSION.LBS_TO_KG).toBe(0.453592);
+  });
+
+  it('exposes INCHES_TO_CM', () => {
+    expect(UNIT_CONVERSION.INCHES_TO_CM).toBe(2.54);
+  });
+
+  it('exposes FEET_TO_CM', () => {
+    expect(UNIT_CONVERSION.FEET_TO_CM).toBe(30.48);
+  });
+});
+
+describe('lbsToKg', () => {
+  it('converts 1 lb to ~0.4536 kg', () => {
+    expect(lbsToKg(1)).toBeCloseTo(0.453592, 5);
+  });
+
+  it('converts 0 lbs to 0 kg', () => {
+    expect(lbsToKg(0)).toBe(0);
+  });
+
+  it('converts 150 lbs correctly', () => {
+    expect(lbsToKg(150)).toBeCloseTo(150 * 0.453592, 4);
+  });
+});
+
+describe('kgToLbs', () => {
+  it('converts 80 kg to ~176.37 lbs', () => {
+    expect(kgToLbs(80)).toBeCloseTo(176.37, 1);
+  });
+
+  it('converts 0 kg to 0 lbs', () => {
+    expect(kgToLbs(0)).toBe(0);
+  });
+
+  it('converts 1 kg to ~2.2046 lbs', () => {
+    expect(kgToLbs(1)).toBeCloseTo(2.2046, 3);
+  });
+});
+
+describe('lbsToKg / kgToLbs round-trip', () => {
+  it('round-trips 80 kg', () => {
+    expect(lbsToKg(kgToLbs(80))).toBeCloseTo(80, 5);
+  });
+
+  it('round-trips 150 lbs', () => {
+    expect(kgToLbs(lbsToKg(150))).toBeCloseTo(150, 5);
+  });
+});
+
+describe('cmToInches', () => {
+  it('converts 2.54 cm to 1 inch', () => {
+    expect(cmToInches(2.54)).toBeCloseTo(1, 5);
+  });
+
+  it('converts 0 cm to 0 inches', () => {
+    expect(cmToInches(0)).toBe(0);
+  });
+
+  it('converts 180 cm to ~70.87 inches', () => {
+    expect(cmToInches(180)).toBeCloseTo(70.866, 2);
+  });
+});
+
+describe('inchesToCm', () => {
+  it('converts 1 inch to 2.54 cm', () => {
+    expect(inchesToCm(1)).toBeCloseTo(2.54, 5);
+  });
+
+  it('converts 0 inches to 0 cm', () => {
+    expect(inchesToCm(0)).toBe(0);
+  });
+
+  it('converts 12 inches to ~30.48 cm', () => {
+    expect(inchesToCm(12)).toBeCloseTo(30.48, 5);
+  });
+});
+
+describe('cmToInches / inchesToCm round-trip', () => {
+  it('round-trips 180 cm', () => {
+    expect(inchesToCm(cmToInches(180))).toBeCloseTo(180, 5);
+  });
+
+  it('round-trips 71 inches', () => {
+    expect(cmToInches(inchesToCm(71))).toBeCloseTo(71, 5);
+  });
+});
+
+describe('cmToFeetAndInches', () => {
+  it('converts 180 cm to 5 feet 11 inches', () => {
+    expect(cmToFeetAndInches(180)).toEqual({ feet: 5, inches: 11 });
+  });
+
+  it('converts 182.88 cm (exactly 6 feet) to 6 feet 0 inches', () => {
+    expect(cmToFeetAndInches(182.88)).toEqual({ feet: 6, inches: 0 });
+  });
+
+  it('normalizes a value that would produce 5\'12" into 6\'0"', () => {
+    // 181.7 cm → totalInches ≈ 71.535 → feet=5, remainder≈11.5 → rounds to 12 → normalizes to 6'0"
+    expect(cmToFeetAndInches(181.7)).toEqual({ feet: 6, inches: 0 });
+  });
+
+  it('converts 0 cm to 0 feet 0 inches', () => {
+    expect(cmToFeetAndInches(0)).toEqual({ feet: 0, inches: 0 });
+  });
+});
+
+describe('feetAndInchesToCm', () => {
+  it('converts 5\'11" to ~180.34 cm', () => {
+    expect(feetAndInchesToCm(5, 11)).toBeCloseTo(180.34, 1);
+  });
+
+  it('converts 6\'0" to ~182.88 cm', () => {
+    expect(feetAndInchesToCm(6, 0)).toBeCloseTo(182.88, 2);
+  });
+
+  it('converts 0\'0" to 0 cm', () => {
+    expect(feetAndInchesToCm(0, 0)).toBe(0);
+  });
+});
+
+describe('feetAndInchesToCm / cmToFeetAndInches round-trip', () => {
+  it('round-trips 5\'11"', () => {
+    const cm = feetAndInchesToCm(5, 11);
+    expect(cmToFeetAndInches(cm)).toEqual({ feet: 5, inches: 11 });
+  });
+
+  it('round-trips 6\'0"', () => {
+    const cm = feetAndInchesToCm(6, 0);
+    expect(cmToFeetAndInches(cm)).toEqual({ feet: 6, inches: 0 });
+  });
+});

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -9,7 +9,7 @@ import { useUser as useClerkUser } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
 import { ChevronRight, Utensils } from 'lucide-react-native';
 import React, { useMemo } from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 const JS_DAY_TO_API_DAY: Record<number, Day> = {
@@ -43,9 +43,11 @@ export default function DashboardPage() {
     return d.toISOString().split('T')[0];
   }, [today.toDateString()]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { data: savedPlan } = useSavedWeekPlanQuery(weekStartStr);
-  const { data: targets } = useUserTargetsQuery();
-  const { data: user } = useUserQuery();
+  const { data: savedPlan, isLoading: isLoadingPlan } = useSavedWeekPlanQuery(weekStartStr);
+  const { data: targets, isLoading: isLoadingTargets } = useUserTargetsQuery();
+  const { data: user, isLoading: isLoadingUser } = useUserQuery();
+
+  const isLoading = isLoadingPlan || isLoadingTargets || isLoadingUser;
 
   // Derive today's plan
   const todayPlan = useMemo(() => {
@@ -160,6 +162,12 @@ export default function DashboardPage() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
+      {isLoading && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.light.primary} testID="home-loading-indicator" />
+        </View>
+      )}
+      {!isLoading && (
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {/* Header */}
         <View style={styles.header}>
@@ -269,6 +277,7 @@ export default function DashboardPage() {
           </View>
         </View>
       </ScrollView>
+      )}
     </SafeAreaView>
   );
 }
@@ -277,6 +286,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: Colors.light.background,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   scrollContent: {
     gap: 24,

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -9,7 +9,14 @@ import { useUser as useClerkUser } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
 import { ChevronRight, Utensils } from 'lucide-react-native';
 import React, { useMemo } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 const JS_DAY_TO_API_DAY: Record<number, Day> = {
@@ -164,119 +171,123 @@ export default function DashboardPage() {
     <SafeAreaView style={styles.container} edges={['top']}>
       {isLoading && (
         <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={Colors.light.primary} testID="home-loading-indicator" />
+          <ActivityIndicator
+            size="large"
+            color={Colors.light.primary}
+            testID="home-loading-indicator"
+          />
         </View>
       )}
       {!isLoading && (
-      <ScrollView contentContainerStyle={styles.scrollContent}>
-        {/* Header */}
-        <View style={styles.header}>
-          <Text style={styles.headerTitle}>
-            {greeting}, {userName}
-          </Text>
-          <Text style={styles.headerSubtitle}>
-            Let&apos;s make today healthy · {dayOfWeek}, {monthName} {day}
-          </Text>
-        </View>
-
-        {/* Health Score Card */}
-        <TouchableOpacity
-          style={styles.scoreCard}
-          onPress={() => router.push('/health-score')}
-          activeOpacity={0.9}
-        >
-          <View style={styles.scoreHeader}>
-            <View>
-              <Text style={styles.scoreLabel}>Health Score</Text>
-              <Text style={styles.scoreValue}>{healthScore.overall}</Text>
-            </View>
-            <View style={styles.statusBadge}>
-              <Text style={styles.statusText}>
-                {healthScore.overall >= 90
-                  ? 'Excellent'
-                  : healthScore.overall >= 70
-                    ? 'Good'
-                    : healthScore.overall >= 50
-                      ? 'Fair'
-                      : 'Needs Work'}
-              </Text>
-            </View>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          {/* Header */}
+          <View style={styles.header}>
+            <Text style={styles.headerTitle}>
+              {greeting}, {userName}
+            </Text>
+            <Text style={styles.headerSubtitle}>
+              Let&apos;s make today healthy · {dayOfWeek}, {monthName} {day}
+            </Text>
           </View>
 
-          <View style={styles.scoreDetails}>
-            {[
-              { label: 'Nutrition', value: healthScore.nutrition.score },
-              { label: 'Exercise', value: healthScore.exercise.score },
-              { label: 'Sleep', value: healthScore.sleep.score },
-            ].map((item, i) => (
-              <View key={i} style={styles.scoreItem}>
-                <View style={styles.progressBarBg}>
-                  <View style={[styles.progressBarFill, { width: `${item.value}%` }]} />
-                </View>
-                <Text style={styles.scoreItemLabel}>{item.label}</Text>
+          {/* Health Score Card */}
+          <TouchableOpacity
+            style={styles.scoreCard}
+            onPress={() => router.push('/health-score')}
+            activeOpacity={0.9}
+          >
+            <View style={styles.scoreHeader}>
+              <View>
+                <Text style={styles.scoreLabel}>Health Score</Text>
+                <Text style={styles.scoreValue}>{healthScore.overall}</Text>
               </View>
-            ))}
-          </View>
-        </TouchableOpacity>
+              <View style={styles.statusBadge}>
+                <Text style={styles.statusText}>
+                  {healthScore.overall >= 90
+                    ? 'Excellent'
+                    : healthScore.overall >= 70
+                      ? 'Good'
+                      : healthScore.overall >= 50
+                        ? 'Fair'
+                        : 'Needs Work'}
+                </Text>
+              </View>
+            </View>
 
-        {/* Today's Schedule */}
-        <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Upcoming</Text>
-            <TouchableOpacity
-              onPress={() => router.push('/(tabs)/schedule')}
-              style={styles.viewAllButton}
-            >
-              <Text style={styles.viewAllText}>Full Schedule</Text>
-              <ChevronRight size={24} color={Colors.light.primary} />
-            </TouchableOpacity>
-          </View>
-
-          {upcomingItems.length > 0 ? (
-            <View style={styles.listContainer}>
-              {upcomingItems.map((item, i) => (
-                <TouchableOpacity
-                  key={i}
-                  style={[styles.listItem, i === 0 && styles.activeListItem]}
-                >
-                  <View style={[styles.iconBox, { backgroundColor: `${item.color}15` }]}>
-                    <item.icon size={24} color={item.color} />
+            <View style={styles.scoreDetails}>
+              {[
+                { label: 'Nutrition', value: healthScore.nutrition.score },
+                { label: 'Exercise', value: healthScore.exercise.score },
+                { label: 'Sleep', value: healthScore.sleep.score },
+              ].map((item, i) => (
+                <View key={i} style={styles.scoreItem}>
+                  <View style={styles.progressBarBg}>
+                    <View style={[styles.progressBarFill, { width: `${item.value}%` }]} />
                   </View>
-                  <View style={styles.itemContent}>
-                    <Text style={styles.itemTitle} numberOfLines={1}>
-                      {item.title}
-                    </Text>
-                    <Text style={styles.itemSubtitle} numberOfLines={1}>
-                      {item.subtitle}
-                    </Text>
-                  </View>
-                  <View style={styles.timeBox}>
-                    <View style={styles.timeBadge}>
-                      <Text style={styles.timeText}>{item.time}</Text>
-                    </View>
-                  </View>
-                </TouchableOpacity>
+                  <Text style={styles.scoreItemLabel}>{item.label}</Text>
+                </View>
               ))}
             </View>
-          ) : (
-            <View style={styles.emptyUpcoming}>
-              <Text style={styles.emptyText}>
-                No meals planned yet. Head to the Schedule tab to plan your week!
-              </Text>
-            </View>
-          )}
-        </View>
+          </TouchableOpacity>
 
-        {/* Macros Progress */}
-        <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Today&apos;s Macros</Text>
+          {/* Today's Schedule */}
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Upcoming</Text>
+              <TouchableOpacity
+                onPress={() => router.push('/(tabs)/schedule')}
+                style={styles.viewAllButton}
+              >
+                <Text style={styles.viewAllText}>Full Schedule</Text>
+                <ChevronRight size={24} color={Colors.light.primary} />
+              </TouchableOpacity>
+            </View>
+
+            {upcomingItems.length > 0 ? (
+              <View style={styles.listContainer}>
+                {upcomingItems.map((item, i) => (
+                  <TouchableOpacity
+                    key={i}
+                    style={[styles.listItem, i === 0 && styles.activeListItem]}
+                  >
+                    <View style={[styles.iconBox, { backgroundColor: `${item.color}15` }]}>
+                      <item.icon size={24} color={item.color} />
+                    </View>
+                    <View style={styles.itemContent}>
+                      <Text style={styles.itemTitle} numberOfLines={1}>
+                        {item.title}
+                      </Text>
+                      <Text style={styles.itemSubtitle} numberOfLines={1}>
+                        {item.subtitle}
+                      </Text>
+                    </View>
+                    <View style={styles.timeBox}>
+                      <View style={styles.timeBadge}>
+                        <Text style={styles.timeText}>{item.time}</Text>
+                      </View>
+                    </View>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            ) : (
+              <View style={styles.emptyUpcoming}>
+                <Text style={styles.emptyText}>
+                  No meals planned yet. Head to the Schedule tab to plan your week!
+                </Text>
+              </View>
+            )}
           </View>
-          <View style={styles.card}>
-            <MacroNutrients data={macroData} />
+
+          {/* Macros Progress */}
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Today&apos;s Macros</Text>
+            </View>
+            <View style={styles.card}>
+              <MacroNutrients data={macroData} />
+            </View>
           </View>
-        </View>
-      </ScrollView>
+        </ScrollView>
       )}
     </SafeAreaView>
   );

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -11,7 +11,7 @@ const config = {
   // Ensure lucide-react-native, @tanstack, and reanimated are transformed.
   // Extends the jest-expo default to add project-specific packages.
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|lucide-react-native|@tanstack/.*|react-native-reanimated)',
+    '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|lucide-react-native|@tanstack/.*|react-native-reanimated)',
   ],
 };
 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -8,6 +8,8 @@ const config = {
     '^@/(.*)$': '<rootDir>/$1',
   },
 
+  testPathIgnorePatterns: ['<rootDir>/__tests__/test-utils.tsx'],
+
   // Ensure lucide-react-native, @tanstack, and reanimated are transformed.
   // Extends the jest-expo default to add project-specific packages.
   transformIgnorePatterns: [

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('jest').Config} */
+const config = {
+  preset: 'jest-expo',
+
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+
+  // Ensure lucide-react-native, @tanstack, and reanimated are transformed.
+  // Extends the jest-expo default to add project-specific packages.
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|lucide-react-native|@tanstack/.*|react-native-reanimated)',
+  ],
+};
+
+module.exports = config;

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,71 @@
+import '@testing-library/react-native/extend-expect';
+
+// Silence React Native log warnings in tests
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+  OS: 'ios',
+  select: (obj: Record<string, unknown>) => obj.ios,
+}));
+
+// Mock react-native-reanimated
+jest.mock('react-native-reanimated', () =>
+  require('react-native-reanimated/mock')
+);
+
+// Mock expo-router
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+  usePathname: () => '/',
+  Link: 'Link',
+  Redirect: ({ href }: { href: string }) => null,
+  Stack: { Screen: 'Screen' },
+  Tabs: { Screen: 'Screen' },
+  router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+}));
+
+// Mock Clerk
+jest.mock('@clerk/clerk-expo', () => ({
+  useAuth: () => ({
+    isSignedIn: true,
+    userId: 'test-user-id',
+    getToken: jest.fn().mockResolvedValue('mock-token'),
+  }),
+  useUser: () => ({
+    user: {
+      id: 'test-user-id',
+      firstName: 'Test',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'test@example.com' },
+      emailAddresses: [{ emailAddress: 'test@example.com' }],
+    },
+    isLoaded: true,
+  }),
+  useSignIn: () => ({
+    signIn: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  }),
+  useSignUp: () => ({
+    signUp: { create: jest.fn() },
+    isLoaded: true,
+    setActive: jest.fn(),
+  }),
+  useClerk: () => ({ signOut: jest.fn() }),
+  ClerkProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock expo-secure-store
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+// Mock @react-native-community/datetimepicker
+jest.mock('@react-native-community/datetimepicker', () => 'DateTimePicker');
+
+// Mock expo-haptics
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
+}));

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -78,3 +78,25 @@ jest.mock('expo-haptics', () => ({
   impactAsync: jest.fn(),
   ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
 }));
+
+// theme.ts calls Platform.select at module-init level; mock to avoid ordering issues.
+jest.mock('@/constants/theme', () => ({
+  Colors: {
+    light: {
+      text: '#111827',
+      textMuted: '#6B7280',
+      background: '#F8FAFC',
+      surface: '#FFFFFF',
+      primary: '#2B9D8F',
+      primaryDark: '#1F6D63',
+      tint: '#2B9D8F',
+      secondary: '#FFB74D',
+      success: '#22C55E',
+      error: '#EF4444',
+      charts: { calories: '#FFB74D', protein: '#2B9D8F', carbs: '#8B5CF6', fats: '#EC4899' },
+    },
+  },
+  Shadows: { card: {} },
+  Layout: { cardRadius: 16 },
+  Fonts: { sans: 'system-ui', serif: 'serif', rounded: 'normal', mono: 'monospace' },
+}));

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,9 +1,16 @@
 import '@testing-library/react-native/extend-expect';
 
 // Silence React Native log warnings in tests
-jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+// Platform.select is called at module-init level in theme.ts and OAuthButton.tsx.
+// react-native's index.js resolves Platform as require('./Libraries/Utilities/Platform').default,
+// so the mock must export a `default` property.
+const platformMock = {
   OS: 'ios',
   select: (obj: Record<string, unknown>) => obj['ios'] ?? obj['default'],
+};
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+  ...platformMock,
+  default: platformMock,
 }));
 
 // Mock react-native-reanimated

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -3,7 +3,7 @@ import '@testing-library/react-native/extend-expect';
 // Silence React Native log warnings in tests
 jest.mock('react-native/Libraries/Utilities/Platform', () => ({
   OS: 'ios',
-  select: (obj: Record<string, unknown>) => obj.ios,
+  select: (obj: Record<string, unknown>) => obj['ios'] ?? obj['default'],
 }));
 
 // Mock react-native-reanimated
@@ -21,6 +21,8 @@ jest.mock('expo-router', () => ({
   Stack: { Screen: 'Screen' },
   Tabs: { Screen: 'Screen' },
   router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+  useFocusEffect: jest.fn(),
+  useSegments: () => [],
 }));
 
 // Mock Clerk
@@ -51,7 +53,7 @@ jest.mock('@clerk/clerk-expo', () => ({
     setActive: jest.fn(),
   }),
   useClerk: () => ({ signOut: jest.fn() }),
-  ClerkProvider: ({ children }: { children: React.ReactNode }) => children,
+  ClerkProvider: ({ children }: { children: unknown }) => children,
 }));
 
 // Mock expo-secure-store

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -79,6 +79,20 @@ jest.mock('expo-haptics', () => ({
   ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
 }));
 
+// Mock expo-web-browser — warmUpAsync/coolDownAsync spawn timers that prevent Jest from exiting
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: jest.fn(),
+  warmUpAsync: jest.fn().mockResolvedValue({}),
+  coolDownAsync: jest.fn().mockResolvedValue({}),
+  openAuthSessionAsync: jest.fn().mockResolvedValue({ type: 'cancel' }),
+}));
+
+// Mock expo-auth-session (used by OAuthButton)
+jest.mock('expo-auth-session', () => ({
+  useAuthRequest: jest.fn(() => [null, null, jest.fn()]),
+  makeRedirectUri: jest.fn(() => 'exp://redirect'),
+}));
+
 // theme.ts calls Platform.select at module-init level; mock to avoid ordering issues.
 jest.mock('@/constants/theme', () => ({
   Colors: {

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -14,9 +14,7 @@ jest.mock('react-native/Libraries/Utilities/Platform', () => ({
 }));
 
 // Mock react-native-reanimated
-jest.mock('react-native-reanimated', () =>
-  require('react-native-reanimated/mock')
-);
+jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
 
 // Mock expo-router
 jest.mock('expo-router', () => ({

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,10 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "typecheck": "tsc --noEmit",
     "check": "pnpm lint && pnpm format:check && pnpm typecheck",
-    "generate-client": "openapi-ts"
+    "generate-client": "openapi-ts",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@clerk/clerk-expo": "^2.19.22",
@@ -54,6 +57,8 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.91.1",
+    "@testing-library/react-native": "^12.9.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.1.17",
     "@typescript-eslint/eslint-plugin": "^8.55.0",
     "@typescript-eslint/parser": "^8.55.0",
@@ -62,6 +67,8 @@
     "eslint-config-expo": "~10.0.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "jest": "^29.7.0",
+    "jest-expo": "~54.0.17",
     "prettier": "^3.8.1",
     "typescript": "~5.9.3"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "jest": "^29.7.0",
+    "react-test-renderer": "19.1.0",
     "jest-expo": "~54.0.17",
     "prettier": "^3.8.1",
     "typescript": "~5.9.3"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(6a669d297523d07f150a67f0d4b7ca55)
+        version: 6.0.23(582c718eacc3be6a8267224ee52c2b98)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.33)
@@ -114,6 +114,12 @@ importers:
       '@hey-api/openapi-ts':
         specifier: ^0.91.1
         version: 0.91.1(typescript@5.9.3)
+      '@testing-library/react-native':
+        specifier: ^12.9.0
+        version: 12.9.0(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/react':
         specifier: ~19.1.17
         version: 19.1.17
@@ -138,6 +144,12 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+      jest-expo:
+        specifier: ~54.0.17
+        version: 54.0.17(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@54.0.33)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -664,6 +676,9 @@ packages:
   '@base-org/account@2.0.1':
     resolution: {integrity: sha512-tySVNx+vd6XEynZL0uvB10uKiwnAfThr8AbKTwILVG86mPbLAhEOInQIk+uDnvpTvfdUhC1Bi5T/46JvFoLZQQ==}
 
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
   '@clerk/clerk-expo@2.19.22':
     resolution: {integrity: sha512-w/nwNMd1ir3d/OAlieeg//JPKULCT9dsuwx4U+/Lu8zqAdCb27Q4ie8hDzoM/9+89GxDn1KyoAh4VgRuMiabfQ==}
     engines: {node: '>=18.17.0'}
@@ -1030,6 +1045,19 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   '@jest/create-cache-key-function@29.7.0':
     resolution: {integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1038,12 +1066,45 @@ packages:
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/fake-timers@29.7.0':
     resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/transform@29.7.0':
@@ -1623,6 +1684,21 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/react-native@12.9.0':
+    resolution: {integrity: sha512-wIn/lB1FjV2N4Q7i9PWVRck3Ehwq5pkhAef5X5/bmQ78J/NoOsGbVY2/DG5Y9Lxw+RfE+GvSEh/fe5Tz6sKSvw==}
+    peerDependencies:
+      jest: '>=28.0.0'
+      react: '>=16.8.0'
+      react-native: '>=0.59'
+      react-test-renderer: '>=16.8.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1659,6 +1735,12 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
+  '@types/jsdom@20.0.1':
+    resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1679,6 +1761,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
@@ -1903,6 +1988,10 @@ packages:
   '@zxcvbn-ts/language-common@3.0.4':
     resolution: {integrity: sha512-viSNNnRYtc7ULXzxrQIVUNwHAPSXRtoIwy/Tq4XQQdIknBzw4vz36lQLF6mvhMlTIlpjoN/Z1GFu/fwiAlUSsw==}
 
+  abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -1922,15 +2011,26 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  acorn-globals@7.0.1:
+    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1957,6 +2057,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@6.2.1:
+    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
+    engines: {node: '>=14.16'}
+
   ansi-regex@4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
     engines: {node: '>=6'}
@@ -1964,6 +2068,10 @@ packages:
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -2038,6 +2146,9 @@ packages:
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2245,6 +2356,10 @@ packages:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2252,6 +2367,14 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  char-regex@2.0.2:
+    resolution: {integrity: sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==}
+    engines: {node: '>=12.20'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -2282,6 +2405,9 @@ packages:
   citty@0.2.0:
     resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   cli-cursor@2.1.0:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
     engines: {node: '>=4'}
@@ -2308,6 +2434,13 @@ packages:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
     engines: {node: '>=6'}
 
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
+
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
@@ -2331,6 +2464,10 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -2404,6 +2541,11 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
@@ -2432,11 +2574,25 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  cssom@0.3.8:
+    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
+  cssstyle@2.3.0:
+    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
+    engines: {node: '>=8'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@3.0.2:
+    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
+    engines: {node: '>=12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2479,9 +2635,20 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2528,6 +2695,10 @@ packages:
     resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
     engines: {node: '>=10'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2547,8 +2718,16 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
@@ -2562,6 +2741,11 @@ packages:
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -2592,6 +2776,10 @@ packages:
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2605,6 +2793,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   env-editor@0.4.2:
@@ -2673,6 +2865,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-expo@10.0.0:
     resolution: {integrity: sha512-/XC/DvniUWTzU7Ypb/cLDhDD4DXqEio4lug1ObD/oQ9Hcx3OVOR8Mkp4u6U4iGoZSJyIQmIk3WVHe/P1NYUXKw==}
@@ -2813,6 +3010,18 @@ packages:
 
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   expo-application@7.0.8:
     resolution: {integrity: sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==}
@@ -3085,6 +3294,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
     engines: {node: '>=8'}
@@ -3138,6 +3351,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -3248,19 +3465,42 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.1:
     resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
@@ -3285,9 +3525,18 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3378,6 +3627,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -3415,6 +3668,9 @@ packages:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3426,6 +3682,10 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -3483,6 +3743,22 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3492,9 +3768,71 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-environment-jsdom@29.7.0:
+    resolution: {integrity: sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-expo@54.0.17:
+    resolution: {integrity: sha512-LyIhrsP4xvHEEcR1R024u/LBj3uPpAgB+UljgV+YXWkEHjprnr0KpE4tROsMNYCVTM1pPlAnPuoBmn5gnAN9KA==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+      react-server-dom-webpack: ~19.0.4 || ~19.1.5 || ~19.2.4
+    peerDependenciesMeta:
+      react-server-dom-webpack:
+        optional: true
 
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
@@ -3502,6 +3840,14 @@ packages:
 
   jest-haste-map@29.7.0:
     resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-message-util@29.7.0:
@@ -3512,8 +3858,37 @@ packages:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
   jest-regex-util@29.6.3:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-util@29.7.0:
@@ -3524,9 +3899,32 @@ packages:
     resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-watch-select-projects@2.0.0:
+    resolution: {integrity: sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==}
+
+  jest-watch-typeahead@2.2.1:
+    resolution: {integrity: sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==}
+    engines: {node: ^14.17.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      jest: ^27.0.0 || ^28.0.0 || ^29.0.0
+
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jimp-compact@0.16.1:
     resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
@@ -3555,6 +3953,15 @@ packages:
 
   jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
+
+  jsdom@20.0.3:
+    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3733,6 +4140,10 @@ packages:
       react-native: '*'
       react-native-svg: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
 
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -3842,6 +4253,14 @@ packages:
     resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
     engines: {node: '>=4'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.1.2:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
@@ -3936,11 +4355,18 @@ packages:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
@@ -4004,6 +4430,10 @@ packages:
   onetime@2.0.1:
     resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
     engines: {node: '>=4'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -4077,6 +4507,9 @@ packages:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
     engines: {node: '>=10'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -4128,6 +4561,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -4203,9 +4640,15 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
@@ -4224,6 +4667,9 @@ packages:
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -4366,6 +4812,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-test-renderer@19.1.0:
+    resolution: {integrity: sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==}
+    peerDependencies:
+      react: ^19.1.0
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -4373,6 +4824,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -4420,6 +4875,13 @@ packages:
   requireg@0.2.2:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4486,9 +4948,16 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -4604,6 +5073,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
@@ -4612,8 +5085,15 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.6:
+    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
@@ -4633,12 +5113,21 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stack-generator@2.0.10:
+    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  stacktrace-gps@3.1.2:
+    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
+
+  stacktrace-js@2.0.2:
+    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
@@ -4673,6 +5162,14 @@ packages:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
 
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
+  string-length@5.0.1:
+    resolution: {integrity: sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==}
+    engines: {node: '>=12.20'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4704,9 +5201,25 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -4758,6 +5271,9 @@ packages:
     resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -4818,8 +5334,16 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -4908,6 +5432,10 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -4923,6 +5451,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -4970,6 +5501,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -4995,6 +5530,10 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -5011,12 +5550,29 @@ packages:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-url-without-unicode@8.0.0-3:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
+
+  whatwg-url@11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -5122,6 +5678,10 @@ packages:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
 
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
     engines: {node: '>=4.0.0'}
@@ -5133,6 +5693,9 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -5840,6 +6403,8 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@bcoe/v8-coverage@0.2.3': {}
+
   '@clerk/clerk-expo@2.19.22(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bs58@5.0.0)(bufferutil@4.1.0)(expo-auth-session@7.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(expo-crypto@15.0.8(expo@54.0.33))(expo-secure-store@15.0.8(expo@54.0.33))(expo-web-browser@15.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@clerk/clerk-js': 5.122.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.1.0))(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -6154,7 +6719,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
-      expo-router: 6.0.23(6a669d297523d07f150a67f0d4b7ca55)
+      expo-router: 6.0.23(582c718eacc3be6a8267224ee52c2b98)
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -6493,6 +7058,50 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 25.2.3
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.2.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/create-cache-key-function@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -6504,6 +7113,17 @@ snapshots:
       '@types/node': 25.2.3
       jest-mock: 29.7.0
 
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
@@ -6513,9 +7133,67 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 25.2.3
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
+
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
 
   '@jest/transform@29.7.0':
     dependencies:
@@ -7248,6 +7926,19 @@ snapshots:
       '@tanstack/query-core': 5.90.20
       react: 19.1.0
 
+  '@testing-library/react-native@12.9.0(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      jest-matcher-utils: 29.7.0
+      pretty-format: 29.7.0
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+      react-test-renderer: 19.1.0(react@19.1.0)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+
+  '@tootallnate/once@2.0.0': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -7296,6 +7987,17 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
+  '@types/jsdom@20.0.1':
+    dependencies:
+      '@types/node': 25.2.3
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -7313,6 +8015,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/uuid@8.3.4': {}
 
@@ -7529,6 +8233,8 @@ snapshots:
 
   '@zxcvbn-ts/language-common@3.0.4': {}
 
+  abab@2.0.6: {}
+
   abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
     optionalDependencies:
       typescript: 5.9.3
@@ -7543,11 +8249,26 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-globals@7.0.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-walk: 8.3.5
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.15.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -7572,9 +8293,13 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@6.2.1: {}
+
   ansi-regex@4.1.1: {}
 
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
 
   ansi-styles@3.2.1:
     dependencies:
@@ -7677,6 +8402,8 @@ snapshots:
   async-function@1.0.0: {}
 
   async-limiter@1.0.1: {}
+
+  asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -7963,12 +8690,21 @@ snapshots:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  char-regex@2.0.2: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -8006,6 +8742,8 @@ snapshots:
 
   citty@0.2.0: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   cli-cursor@2.1.0:
     dependencies:
       restore-cursor: 2.0.0
@@ -8030,6 +8768,10 @@ snapshots:
 
   clsx@1.2.1: {}
 
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.3: {}
+
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -8053,6 +8795,10 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@12.1.0: {}
 
@@ -8123,6 +8869,21 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  create-jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   cross-fetch@3.2.0:
     dependencies:
       node-fetch: 2.7.0
@@ -8158,9 +8919,23 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  cssom@0.3.8: {}
+
+  cssom@0.5.0: {}
+
+  cssstyle@2.3.0:
+    dependencies:
+      cssom: 0.3.8
+
   csstype@3.1.3: {}
 
   csstype@3.2.3: {}
+
+  data-urls@3.0.2:
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -8194,7 +8969,13 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decimal.js@10.6.0: {}
+
   decode-uri-component@0.2.2: {}
+
+  dedent@1.7.2(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
 
   deep-extend@0.6.0: {}
 
@@ -8233,6 +9014,8 @@ snapshots:
 
   delay@5.0.0: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -8243,7 +9026,11 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-newline@3.1.0: {}
+
   detect-node-es@1.1.0: {}
+
+  diff-sequences@29.6.3: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -8258,6 +9045,10 @@ snapshots:
       entities: 4.5.0
 
   domelementtype@2.3.0: {}
+
+  domexception@4.0.0:
+    dependencies:
+      webidl-conversions: 7.0.0
 
   domhandler@5.0.3:
     dependencies:
@@ -8287,6 +9078,8 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
+  emittery@0.13.1: {}
+
   emoji-regex@8.0.0: {}
 
   encodeurl@1.0.2: {}
@@ -8294,6 +9087,8 @@ snapshots:
   encodeurl@2.0.0: {}
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   env-editor@0.4.2: {}
 
@@ -8421,6 +9216,14 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-expo@10.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -8628,6 +9431,28 @@ snapshots:
 
   exec-async@2.2.0: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  exit@0.1.2: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
   expo-application@7.0.8(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10)
@@ -8729,7 +9554,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
 
-  expo-router@6.0.23(6a669d297523d07f150a67f0d4b7ca55):
+  expo-router@6.0.23(582c718eacc3be6a8267224ee52c2b98):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -8762,6 +9587,7 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.1.0)
       vaul: 1.1.2(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     optionalDependencies:
+      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom: 19.1.0(react@19.1.0)
       react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       react-native-reanimated: 4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
@@ -8937,6 +9763,14 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
@@ -8986,6 +9820,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -9096,6 +9932,12 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-encoding-sniffer@3.0.0:
+    dependencies:
+      whatwg-encoding: 2.0.0
+
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -9104,6 +9946,21 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -9111,11 +9968,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
 
   hyphenate-style-name@1.1.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb-keyval@6.2.1: {}
 
@@ -9134,7 +9997,14 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
+
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -9224,6 +10094,8 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-fn@2.1.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -9255,6 +10127,8 @@ snapshots:
 
   is-plain-obj@2.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -9267,6 +10141,8 @@ snapshots:
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -9326,6 +10202,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -9353,6 +10258,121 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-circus@29.7.0(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.2.3
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2(babel-plugin-macros@3.1.0)
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+
+  jest-environment-jsdom@29.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/jsdom': 20.0.1
+      '@types/node': 25.2.3
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+      jsdom: 20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jest-environment-node@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
@@ -9361,6 +10381,33 @@ snapshots:
       '@types/node': 25.2.3
       jest-mock: 29.7.0
       jest-util: 29.7.0
+
+  jest-expo@54.0.17(@babel/core@7.29.0)(bufferutil@4.1.0)(expo@54.0.33)(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@expo/config': 12.0.13
+      '@expo/json-file': 10.0.8
+      '@jest/create-cache-key-function': 29.7.0
+      '@jest/globals': 29.7.0
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(bufferutil@4.1.0)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)(utf-8-validate@5.0.10)
+      jest-environment-jsdom: 29.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      jest-snapshot: 29.7.0
+      jest-watch-select-projects: 2.0.0
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0))
+      json5: 2.2.3
+      lodash: 4.17.23
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+      react-test-renderer: 19.1.0(react@19.1.0)
+      server-only: 0.0.1
+      stacktrace-js: 2.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - canvas
+      - jest
+      - react
+      - supports-color
+      - utf-8-validate
 
   jest-get-type@29.6.3: {}
 
@@ -9380,6 +10427,18 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-message-util@29.7.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -9398,7 +10457,108 @@ snapshots:
       '@types/node': 25.2.3
       jest-util: 29.7.0
 
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
   jest-regex-util@29.6.3: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.11
+      resolve.exports: 2.0.3
+      slash: 3.0.0
+
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.2.3
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.2.3
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.3
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
 
   jest-util@29.7.0:
     dependencies:
@@ -9418,12 +10578,52 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
+  jest-watch-select-projects@2.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 3.0.0
+      prompts: 2.4.2
+
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)):
+    dependencies:
+      ansi-escapes: 6.2.1
+      chalk: 4.1.2
+      jest: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+      jest-regex-util: 29.6.3
+      jest-watcher: 29.7.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.2.0
+
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.2.3
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
   jest-worker@29.7.0:
     dependencies:
       '@types/node': 25.2.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@25.2.3)(babel-plugin-macros@3.1.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jimp-compact@0.16.1: {}
 
@@ -9445,6 +10645,39 @@ snapshots:
       argparse: 2.0.1
 
   jsc-safe-url@0.2.4: {}
+
+  jsdom@20.0.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.15.0
+      acorn-globals: 7.0.1
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.6.0
+      domexception: 4.0.0
+      escodegen: 2.1.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -9581,6 +10814,10 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
       react-native-svg: 15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   makeerror@1.0.12:
     dependencies:
@@ -9794,6 +11031,10 @@ snapshots:
 
   mimic-fn@1.2.0: {}
 
+  mimic-fn@2.1.0: {}
+
+  min-indent@1.0.1: {}
+
   minimatch@10.1.2:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
@@ -9862,11 +11103,17 @@ snapshots:
       semver: 7.7.4
       validate-npm-package-name: 5.0.1
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
+
+  nwsapi@2.2.23: {}
 
   nypm@0.6.5:
     dependencies:
@@ -9939,6 +11186,10 @@ snapshots:
   onetime@2.0.1:
     dependencies:
       mimic-fn: 1.2.0
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   open@11.0.0:
     dependencies:
@@ -10046,6 +11297,10 @@ snapshots:
     dependencies:
       pngjs: 3.4.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -10076,6 +11331,10 @@ snapshots:
   picomatch@4.0.3: {}
 
   pirates@4.0.7: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   pkg-types@2.3.0:
     dependencies:
@@ -10144,7 +11403,13 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   qrcode-terminal@0.11.0: {}
 
@@ -10164,6 +11429,8 @@ snapshots:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
+
+  querystringify@2.2.0: {}
 
   queue@6.0.2:
     dependencies:
@@ -10366,9 +11633,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  react-test-renderer@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-is: 19.2.4
+      scheduler: 0.26.0
+
   react@19.1.0: {}
 
   readdirp@5.0.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -10426,6 +11704,12 @@ snapshots:
       nested-error-stacks: 2.0.1
       rc: 1.2.8
       resolve: 1.7.1
+
+  requires-port@1.0.0: {}
+
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
 
   resolve-from@4.0.0: {}
 
@@ -10502,7 +11786,13 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sax@1.4.4: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
 
@@ -10631,14 +11921,23 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slash@5.1.0: {}
+
   slugify@1.6.6: {}
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
 
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+
+  source-map@0.5.6: {}
 
   source-map@0.5.7: {}
 
@@ -10650,11 +11949,26 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stack-generator@2.0.10:
+    dependencies:
+      stackframe: 1.3.4
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
 
   stackframe@1.3.4: {}
+
+  stacktrace-gps@3.1.2:
+    dependencies:
+      source-map: 0.5.6
+      stackframe: 1.3.4
+
+  stacktrace-js@2.0.2:
+    dependencies:
+      error-stack-parser: 2.1.4
+      stack-generator: 2.0.10
+      stacktrace-gps: 3.1.2
 
   stacktrace-parser@0.1.11:
     dependencies:
@@ -10680,6 +11994,16 @@ snapshots:
       stream-chain: 2.2.5
 
   strict-uri-encode@2.0.0: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+
+  string-length@5.0.1:
+    dependencies:
+      char-regex: 2.0.2
+      strip-ansi: 7.2.0
 
   string-width@4.2.3:
     dependencies:
@@ -10739,7 +12063,19 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 
@@ -10787,6 +12123,8 @@ snapshots:
       dequal: 2.0.3
       react: 19.1.0
       use-sync-external-store: 1.6.0(react@19.1.0)
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
 
@@ -10847,7 +12185,18 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
+
+  tr46@3.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -10937,6 +12286,8 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  universalify@0.2.0: {}
+
   unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
@@ -10973,6 +12324,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
   use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -11007,6 +12363,12 @@ snapshots:
 
   uuid@8.3.2: {}
 
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
@@ -11039,6 +12401,10 @@ snapshots:
 
   vlq@1.0.1: {}
 
+  w3c-xmlserializer@4.0.0:
+    dependencies:
+      xml-name-validator: 4.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -11053,13 +12419,26 @@ snapshots:
 
   webidl-conversions@5.0.0: {}
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@2.0.0:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url-without-unicode@8.0.0-3:
     dependencies:
       buffer: 5.7.1
       punycode: 2.3.1
       webidl-conversions: 5.0.0
+
+  whatwg-url@11.0.0:
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -11168,6 +12547,8 @@ snapshots:
       simple-plist: 1.3.1
       uuid: 7.0.3
 
+  xml-name-validator@4.0.0: {}
+
   xml2js@0.6.0:
     dependencies:
       sax: 1.4.4
@@ -11176,6 +12557,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@4.0.3: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      react-test-renderer:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

Adds the first real testing infrastructure to the frontend. Until now the Expo 54 / React Native 0.81 app had zero tests, which made it risky to refactor shared hooks and utilities or accept PRs that touched them. This PR sets up Jest with the jest-expo preset and React Native Testing Library, configures global mocks for Clerk, expo-router, reanimated, and native modules, and adds a shared test-utils wrapper that sets up a QueryClient for component tests.

Ships 145 tests across three tiers. Utility tests cover unit conversions, health score scoring branches, and the meal plan mapper. Hook tests cover useUserProfile, useOnboarding, and useScheduleEditing. Screen integration tests cover sign-in (including the Clerk 2FA branch), onboarding step 1, and the home tab.

Also adds a test job to the frontend CI workflow that runs in parallel with lint and typecheck, so every PR after this one is gated on tests passing.

## Relationship to other work

Depends on the meal plan mapper added in #131 and the Clerk auth flow. Backs the automated cases tracked in docs/testing/VerificationTestInventory.md and the broader strategy laid out in docs/Verification&Validation.md, so future feature work can attach coverage to those plans instead of relying on manual checks.

## Issues

Closes #177
