### PR TITLE
feat: force light mode for Clerk auth components

### DIFF
--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -34,7 +34,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'sophros',
-  userInterfaceStyle: 'automatic',
+  userInterfaceStyle: 'light',
   newArchEnabled: true,
   ios: {
     supportsTablet: true,

--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -75,9 +75,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         imageWidth: 200,
         resizeMode: 'contain',
         backgroundColor: '#ffffff',
-        dark: {
-          backgroundColor: '#000000',
-        },
       },
     ],
   ],

--- a/frontend/app/(auth)/sign-in.tsx
+++ b/frontend/app/(auth)/sign-in.tsx
@@ -1,10 +1,5 @@
 import { AuthView } from '@clerk/expo/native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function SignInScreen() {
-  return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <AuthView mode="signInOrUp" />
-    </SafeAreaView>
-  );
+  return <AuthView mode="signInOrUp" />;
 }


### PR DESCRIPTION
## Summary

Forces the Clerk native AuthView to render in light mode regardless of the device's dark mode setting, by switching userInterfaceStyle from automatic to light in app.config.ts. The rest of the app was already pinned to light, but Clerk's SwiftUI and Jetpack Compose views follow the OS setting by default, so dark-mode devices were seeing mismatched auth screens.

## Issues

Closes #211
