### PR TITLE
feat: move profile items to onboarding flow

### DIFF
--- a/frontend/__tests__/hooks/useOnboarding.test.tsx
+++ b/frontend/__tests__/hooks/useOnboarding.test.tsx
@@ -90,6 +90,8 @@ describe('useOnboarding', () => {
     expect(result.current.errors.height).toBeDefined();
     expect(result.current.errors.gender).toBeDefined();
     expect(result.current.errors.activityLevel).toBeDefined();
+    expect(result.current.errors.targetWeight).toBeDefined();
+    expect(result.current.errors.targetDate).toBeDefined();
   });
 
   it('validate() with valid values returns true and no errors', () => {
@@ -100,6 +102,8 @@ describe('useOnboarding', () => {
       result.current.updateField('height', VALID_HEIGHT);
       result.current.updateField('gender', 'male');
       result.current.updateField('activityLevel', 'moderate');
+      result.current.updateField('targetWeight', '65');
+      result.current.updateField('targetDate', '2026-12-31');
     });
     let isValid: boolean;
     act(() => {
@@ -177,6 +181,8 @@ describe('useOnboarding', () => {
       result.current.updateField('weight', VALID_WEIGHT);
       result.current.updateField('height', VALID_HEIGHT);
       result.current.updateField('activityLevel', 'moderate');
+      result.current.updateField('targetWeight', '65');
+      result.current.updateField('targetDate', '2026-12-31');
     });
 
     expect(result.current.canSubmit()).toBe(true);
@@ -194,6 +200,8 @@ describe('useOnboarding', () => {
       result.current.updateField('weight', VALID_WEIGHT);
       result.current.updateField('height', VALID_HEIGHT);
       result.current.updateField('activityLevel', 'moderate');
+      result.current.updateField('targetWeight', '65');
+      result.current.updateField('targetDate', '2026-12-31');
     });
 
     let submitResult: boolean;
@@ -239,6 +247,8 @@ describe('useOnboarding', () => {
       result.current.updateField('weight', VALID_WEIGHT);
       result.current.updateField('height', VALID_HEIGHT);
       result.current.updateField('activityLevel', 'moderate');
+      result.current.updateField('targetWeight', '65');
+      result.current.updateField('targetDate', '2026-12-31');
     });
 
     let success: boolean;

--- a/frontend/__tests__/screens/onboarding-step1.test.tsx
+++ b/frontend/__tests__/screens/onboarding-step1.test.tsx
@@ -51,7 +51,7 @@ describe('Step1Screen (Onboarding)', () => {
 
   it('shows the step progress indicator', () => {
     renderStep1();
-    expect(screen.getByText('Step 1 of 5')).toBeTruthy();
+    expect(screen.getByText('Step 1 of 6')).toBeTruthy();
   });
 
   it('Continue button is disabled when age and gender are empty', () => {

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,9 +1,11 @@
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { ClerkProvider } from '@clerk/expo';
 import { tokenCache } from '@clerk/expo/token-cache';
 import { DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
 
 import { queryClient } from '@/config/queryClient';
@@ -32,26 +34,33 @@ client.setConfig({
 
 export default function RootLayout() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
-        <UserProvider>
-          <OnboardingProvider>
-            <ThemeProvider value={DefaultTheme}>
-              <Stack>
-                <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                <Stack.Screen name="index" options={{ headerShown: false }} />
-                <Stack.Screen name="onboarding" options={{ headerShown: false }} />
-                <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-                <Stack.Screen name="week-planning" options={{ headerShown: false }} />
-                <Stack.Screen name="health-score" options={{ headerShown: false }} />
-                <Stack.Screen name="profile/edit" options={{ headerShown: false }} />
-                <Stack.Screen name="profile/dietary-preferences" options={{ headerShown: false }} />
-              </Stack>
-              <StatusBar style="dark" />
-            </ThemeProvider>
-          </OnboardingProvider>
-        </UserProvider>
-      </ClerkProvider>
-    </QueryClientProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <QueryClientProvider client={queryClient}>
+        <ClerkProvider tokenCache={tokenCache} publishableKey={publishableKey}>
+          <UserProvider>
+            <OnboardingProvider>
+              <BottomSheetModalProvider>
+                <ThemeProvider value={DefaultTheme}>
+                  <Stack>
+                    <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+                    <Stack.Screen name="index" options={{ headerShown: false }} />
+                    <Stack.Screen name="onboarding" options={{ headerShown: false }} />
+                    <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+                    <Stack.Screen name="week-planning" options={{ headerShown: false }} />
+                    <Stack.Screen name="health-score" options={{ headerShown: false }} />
+                    <Stack.Screen name="profile/edit" options={{ headerShown: false }} />
+                    <Stack.Screen
+                      name="profile/dietary-preferences"
+                      options={{ headerShown: false }}
+                    />
+                  </Stack>
+                  <StatusBar style="dark" />
+                </ThemeProvider>
+              </BottomSheetModalProvider>
+            </OnboardingProvider>
+          </UserProvider>
+        </ClerkProvider>
+      </QueryClientProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/frontend/app/onboarding/_layout.tsx
+++ b/frontend/app/onboarding/_layout.tsx
@@ -54,6 +54,7 @@ export default function OnboardingLayout() {
         <Stack.Screen name="step3" />
         <Stack.Screen name="step4" />
         <Stack.Screen name="step5" />
+        <Stack.Screen name="step6" />
         <Stack.Screen name="done" options={{ headerShown: false }} />
       </Stack>
     </OnboardingProvider>

--- a/frontend/app/onboarding/index.tsx
+++ b/frontend/app/onboarding/index.tsx
@@ -6,7 +6,7 @@ import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-nati
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function WelcomeScreen() {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, signOut } = useAuth();
 
   if (!isSignedIn) {
     return <Redirect href={'/(auth)/sign-in'} />;
@@ -65,6 +65,13 @@ export default function WelcomeScreen() {
               activeOpacity={0.8}
             >
               <Text style={styles.continueButtonText}>Get Started</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.signOutButton}
+              onPress={() => signOut()}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.signOutButtonText}>Sign Out</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -153,5 +160,14 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: Colors.light.surface,
+  },
+  signOutButton: {
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  signOutButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.light.textMuted,
   },
 });

--- a/frontend/app/onboarding/step1.tsx
+++ b/frontend/app/onboarding/step1.tsx
@@ -31,9 +31,9 @@ export default function Step1Screen() {
         >
           <View style={styles.progressContainer}>
             <View style={styles.progressBar}>
-              <View style={[styles.progressFill, { width: '20%' }]} />
+              <View style={[styles.progressFill, { width: '17%' }]} />
             </View>
-            <Text style={styles.progressText}>Step 1 of 5</Text>
+            <Text style={styles.progressText}>Step 1 of 6</Text>
           </View>
 
           <View style={styles.header}>

--- a/frontend/app/onboarding/step2.tsx
+++ b/frontend/app/onboarding/step2.tsx
@@ -115,9 +115,9 @@ export default function Step2Screen() {
         >
           <View style={styles.progressContainer}>
             <View style={styles.progressBar}>
-              <View style={[styles.progressFill, { width: '40%' }]} />
+              <View style={[styles.progressFill, { width: '33%' }]} />
             </View>
-            <Text style={styles.progressText}>Step 2 of 5</Text>
+            <Text style={styles.progressText}>Step 2 of 6</Text>
           </View>
 
           <View style={styles.header}>

--- a/frontend/app/onboarding/step3.tsx
+++ b/frontend/app/onboarding/step3.tsx
@@ -19,7 +19,7 @@ export default function Step3Screen() {
           <View style={styles.progressBar}>
             <View style={[styles.progressFill, { width: '50%' }]} />
           </View>
-          <Text style={styles.progressText}>Step 3 of 5</Text>
+          <Text style={styles.progressText}>Step 3 of 6</Text>
         </View>
 
         <View style={styles.header}>

--- a/frontend/app/onboarding/step4.tsx
+++ b/frontend/app/onboarding/step4.tsx
@@ -17,9 +17,9 @@ export default function Step4Screen() {
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <View style={styles.progressContainer}>
           <View style={styles.progressBar}>
-            <View style={[styles.progressFill, { width: '80%' }]} />
+            <View style={[styles.progressFill, { width: '67%' }]} />
           </View>
-          <Text style={styles.progressText}>Step 4 of 5</Text>
+          <Text style={styles.progressText}>Step 4 of 6</Text>
         </View>
 
         <View style={styles.header}>

--- a/frontend/app/onboarding/step5.tsx
+++ b/frontend/app/onboarding/step5.tsx
@@ -100,11 +100,10 @@ export default function Step5Screen() {
               <Text style={styles.fieldLabel}>Target Date</Text>
               <Text style={styles.fieldDescription}>When do you want to reach your goal?</Text>
               {Platform.OS === 'android' && (
-                <TouchableOpacity
-                  style={styles.dateButton}
-                  onPress={() => setShowDatePicker(true)}
-                >
-                  <Text style={data.targetDate ? styles.dateButtonText : styles.dateButtonPlaceholder}>
+                <TouchableOpacity style={styles.dateButton} onPress={() => setShowDatePicker(true)}>
+                  <Text
+                    style={data.targetDate ? styles.dateButtonText : styles.dateButtonPlaceholder}
+                  >
                     {data.targetDate || 'Select a date'}
                   </Text>
                 </TouchableOpacity>
@@ -118,9 +117,7 @@ export default function Step5Screen() {
                   onChange={handleDateChange}
                 />
               )}
-              {errors.targetDate && (
-                <Text style={styles.errorText}>{errors.targetDate}</Text>
-              )}
+              {errors.targetDate && <Text style={styles.errorText}>{errors.targetDate}</Text>}
             </View>
 
             <TimePickerInput

--- a/frontend/app/onboarding/step5.tsx
+++ b/frontend/app/onboarding/step5.tsx
@@ -1,3 +1,4 @@
+import { DatePickerInput } from '@/components/DatePickerInput';
 import { MetricInput } from '@/components/MetricInput';
 import { TimePickerInput } from '@/components/TimePickerInput';
 import { Colors, Shadows } from '@/constants/theme';
@@ -5,23 +6,20 @@ import { useOnboarding } from '@/hooks/useOnboarding';
 import { kgToLbs, lbsToKg } from '@/utils/units';
 import { getSleepWarning } from '@/utils/sleep-validation';
 import { router } from 'expo-router';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   KeyboardAvoidingView,
-  Platform,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Step5Screen() {
   const { data, updateField, errors, isSection5Complete } = useOnboarding();
   const [imperialTargetWeight, setImperialTargetWeight] = useState('');
-  const [showDatePicker, setShowDatePicker] = useState(Platform.OS === 'ios');
 
   const canContinue = isSection5Complete();
 
@@ -47,20 +45,11 @@ export default function Step5Screen() {
       (data.targetWeight ? kgToLbs(parseFloat(data.targetWeight)).toString() : '')
     : data.targetWeight;
 
-  const minDate = new Date();
-  minDate.setDate(minDate.getDate() + 7); // At least 1 week from now
-
-  const handleDateChange = (_event: unknown, selectedDate?: Date) => {
-    if (Platform.OS === 'android') {
-      setShowDatePicker(false);
-    }
-    if (selectedDate) {
-      const year = selectedDate.getFullYear();
-      const month = String(selectedDate.getMonth() + 1).padStart(2, '0');
-      const day = String(selectedDate.getDate()).padStart(2, '0');
-      updateField('targetDate', `${year}-${month}-${day}`);
-    }
-  };
+  const minDate = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7); // At least 1 week from now
+    return d;
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
@@ -96,29 +85,13 @@ export default function Step5Screen() {
               />
             </View>
 
-            <View style={styles.dateField}>
-              <Text style={styles.fieldLabel}>Target Date</Text>
-              <Text style={styles.fieldDescription}>When do you want to reach your goal?</Text>
-              {Platform.OS === 'android' && (
-                <TouchableOpacity style={styles.dateButton} onPress={() => setShowDatePicker(true)}>
-                  <Text
-                    style={data.targetDate ? styles.dateButtonText : styles.dateButtonPlaceholder}
-                  >
-                    {data.targetDate || 'Select a date'}
-                  </Text>
-                </TouchableOpacity>
-              )}
-              {showDatePicker && (
-                <DateTimePicker
-                  value={data.targetDate ? new Date(data.targetDate) : minDate}
-                  mode="date"
-                  display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                  minimumDate={minDate}
-                  onChange={handleDateChange}
-                />
-              )}
-              {errors.targetDate && <Text style={styles.errorText}>{errors.targetDate}</Text>}
-            </View>
+            <DatePickerInput
+              label="Target Date"
+              value={data.targetDate}
+              onChange={(v) => updateField('targetDate', v)}
+              minimumDate={minDate}
+              error={errors.targetDate}
+            />
 
             <TimePickerInput
               label="Wake Up Time"
@@ -207,39 +180,6 @@ const styles = StyleSheet.create({
   },
   content: {
     gap: 24,
-  },
-  dateField: {
-    gap: 4,
-  },
-  fieldLabel: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: Colors.light.text,
-  },
-  fieldDescription: {
-    fontSize: 14,
-    color: Colors.light.textMuted,
-    marginBottom: 4,
-  },
-  dateButton: {
-    backgroundColor: Colors.light.surface,
-    borderRadius: 12,
-    padding: 16,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  dateButtonText: {
-    fontSize: 16,
-    color: Colors.light.text,
-  },
-  dateButtonPlaceholder: {
-    fontSize: 16,
-    color: Colors.light.textMuted,
-  },
-  errorText: {
-    fontSize: 13,
-    color: Colors.light.error,
-    marginTop: 4,
   },
   buttonContainer: {
     padding: 20,

--- a/frontend/app/onboarding/step5.tsx
+++ b/frontend/app/onboarding/step5.tsx
@@ -7,20 +7,23 @@ import { getSleepWarning } from '@/utils/sleep-validation';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
 import {
-  ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
+  Platform,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
   View,
 } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Step5Screen() {
-  const { data, updateField, loading, error: apiError, submit } = useOnboarding();
+  const { data, updateField, errors, isSection5Complete } = useOnboarding();
   const [imperialTargetWeight, setImperialTargetWeight] = useState('');
+  const [showDatePicker, setShowDatePicker] = useState(Platform.OS === 'ios');
+
+  const canContinue = isSection5Complete();
 
   const handleTargetWeightChange = (value: string) => {
     if (!data.showImperial) {
@@ -44,12 +47,18 @@ export default function Step5Screen() {
       (data.targetWeight ? kgToLbs(parseFloat(data.targetWeight)).toString() : '')
     : data.targetWeight;
 
-  const handleSubmit = async () => {
-    const success = await submit();
-    if (success) {
-      router.replace('/onboarding/done');
-    } else if (apiError) {
-      Alert.alert('Error', apiError);
+  const minDate = new Date();
+  minDate.setDate(minDate.getDate() + 7); // At least 1 week from now
+
+  const handleDateChange = (_event: unknown, selectedDate?: Date) => {
+    if (Platform.OS === 'android') {
+      setShowDatePicker(false);
+    }
+    if (selectedDate) {
+      const year = selectedDate.getFullYear();
+      const month = String(selectedDate.getMonth() + 1).padStart(2, '0');
+      const day = String(selectedDate.getDate()).padStart(2, '0');
+      updateField('targetDate', `${year}-${month}-${day}`);
     }
   };
 
@@ -64,9 +73,9 @@ export default function Step5Screen() {
         >
           <View style={styles.progressContainer}>
             <View style={styles.progressBar}>
-              <View style={[styles.progressFill, { width: '100%' }]} />
+              <View style={[styles.progressFill, { width: '83%' }]} />
             </View>
-            <Text style={styles.progressText}>Step 5 of 5</Text>
+            <Text style={styles.progressText}>Step 5 of 6</Text>
           </View>
 
           <View style={styles.header}>
@@ -80,10 +89,38 @@ export default function Step5Screen() {
                 label={`Target Weight (${data.showImperial ? 'lbs' : 'kg'})`}
                 value={displayTargetWeight}
                 onChangeText={handleTargetWeightChange}
-                placeholder="Leave blank to maintain current weight"
+                placeholder="Enter your target weight"
                 keyboardType="decimal-pad"
                 unit={data.showImperial ? 'lbs' : 'kg'}
+                error={errors.targetWeight}
               />
+            </View>
+
+            <View style={styles.dateField}>
+              <Text style={styles.fieldLabel}>Target Date</Text>
+              <Text style={styles.fieldDescription}>When do you want to reach your goal?</Text>
+              {Platform.OS === 'android' && (
+                <TouchableOpacity
+                  style={styles.dateButton}
+                  onPress={() => setShowDatePicker(true)}
+                >
+                  <Text style={data.targetDate ? styles.dateButtonText : styles.dateButtonPlaceholder}>
+                    {data.targetDate || 'Select a date'}
+                  </Text>
+                </TouchableOpacity>
+              )}
+              {showDatePicker && (
+                <DateTimePicker
+                  value={data.targetDate ? new Date(data.targetDate) : minDate}
+                  mode="date"
+                  display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                  minimumDate={minDate}
+                  onChange={handleDateChange}
+                />
+              )}
+              {errors.targetDate && (
+                <Text style={styles.errorText}>{errors.targetDate}</Text>
+              )}
             </View>
 
             <TimePickerInput
@@ -110,16 +147,12 @@ export default function Step5Screen() {
 
         <View style={styles.buttonContainer}>
           <TouchableOpacity
-            style={[styles.submitButton, loading && styles.submitButtonDisabled]}
-            onPress={handleSubmit}
-            disabled={loading}
+            style={[styles.continueButton, !canContinue && styles.continueButtonDisabled]}
+            onPress={() => router.push('/onboarding/step6')}
+            disabled={!canContinue}
             activeOpacity={0.8}
           >
-            {loading ? (
-              <ActivityIndicator color={Colors.light.surface} />
-            ) : (
-              <Text style={styles.submitButtonText}>Complete Profile</Text>
-            )}
+            <Text style={styles.continueButtonText}>Continue</Text>
           </TouchableOpacity>
         </View>
       </KeyboardAvoidingView>
@@ -178,6 +211,39 @@ const styles = StyleSheet.create({
   content: {
     gap: 24,
   },
+  dateField: {
+    gap: 4,
+  },
+  fieldLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.text,
+  },
+  fieldDescription: {
+    fontSize: 14,
+    color: Colors.light.textMuted,
+    marginBottom: 4,
+  },
+  dateButton: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  dateButtonText: {
+    fontSize: 16,
+    color: Colors.light.text,
+  },
+  dateButtonPlaceholder: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+  },
+  errorText: {
+    fontSize: 13,
+    color: Colors.light.error,
+    marginTop: 4,
+  },
   buttonContainer: {
     padding: 20,
     paddingBottom: 30,
@@ -186,18 +252,18 @@ const styles = StyleSheet.create({
     borderTopColor: Colors.light.background,
     ...Shadows.card,
   },
-  submitButton: {
+  continueButton: {
     backgroundColor: Colors.light.primary,
     borderRadius: 12,
     paddingVertical: 16,
     alignItems: 'center',
     ...Shadows.card,
   },
-  submitButtonDisabled: {
+  continueButtonDisabled: {
     backgroundColor: Colors.light.textMuted,
     opacity: 0.5,
   },
-  submitButtonText: {
+  continueButtonText: {
     fontSize: 16,
     fontWeight: '600',
     color: Colors.light.surface,

--- a/frontend/app/onboarding/step6.tsx
+++ b/frontend/app/onboarding/step6.tsx
@@ -1,0 +1,269 @@
+import type { Allergy, Cuisine } from '@/api/types.gen';
+import { ChipSelect } from '@/components/ChipSelect';
+import { ALL_ALLERGIES, ALL_CUISINES, DIET_OPTIONS } from '@/constants/dietary';
+import { Colors, Layout, Shadows } from '@/constants/theme';
+import { useOnboarding } from '@/hooks/useOnboarding';
+import { router } from 'expo-router';
+import React from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const DIET_KEY_MAP: Record<string, keyof DietFlags> = {
+  is_gluten_free: 'isGlutenFree',
+  is_ketogenic: 'isKetogenic',
+  is_vegetarian: 'isVegetarian',
+  is_vegan: 'isVegan',
+  is_pescatarian: 'isPescatarian',
+};
+
+type DietFlags = {
+  isGlutenFree: boolean;
+  isKetogenic: boolean;
+  isVegetarian: boolean;
+  isVegan: boolean;
+  isPescatarian: boolean;
+};
+
+export default function Step6Screen() {
+  const { data, updateField, loading, error: apiError, submit } = useOnboarding();
+
+  const toggleAllergy = (allergy: string) => {
+    const a = allergy as Allergy;
+    const updated = data.allergies.includes(a)
+      ? data.allergies.filter((x) => x !== a)
+      : [...data.allergies, a];
+    updateField('allergies', updated);
+  };
+
+  const toggleIncludeCuisine = (cuisine: string) => {
+    const c = cuisine as Cuisine;
+    const updated = data.includeCuisine.includes(c)
+      ? data.includeCuisine.filter((x) => x !== c)
+      : [...data.includeCuisine, c];
+    updateField('includeCuisine', updated);
+  };
+
+  const toggleExcludeCuisine = (cuisine: string) => {
+    const c = cuisine as Cuisine;
+    const updated = data.excludeCuisine.includes(c)
+      ? data.excludeCuisine.filter((x) => x !== c)
+      : [...data.excludeCuisine, c];
+    updateField('excludeCuisine', updated);
+  };
+
+  const toggleDietFlag = (key: keyof DietFlags) => {
+    updateField(key, !data[key]);
+  };
+
+  const handleSubmit = async () => {
+    const success = await submit();
+    if (success) {
+      router.replace('/onboarding/done');
+    } else if (apiError) {
+      Alert.alert('Error', apiError);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.progressContainer}>
+          <View style={styles.progressBar}>
+            <View style={[styles.progressFill, { width: '100%' }]} />
+          </View>
+          <Text style={styles.progressText}>Step 6 of 6</Text>
+        </View>
+
+        <View style={styles.header}>
+          <Text style={styles.title}>Dietary Preferences</Text>
+          <Text style={styles.subtitle}>
+            Help us personalize your meal plans. All fields are optional.
+          </Text>
+        </View>
+
+        <View style={styles.content}>
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Allergies</Text>
+            <ChipSelect
+              options={ALL_ALLERGIES}
+              selected={data.allergies}
+              onToggle={toggleAllergy}
+            />
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Diet Type</Text>
+            {DIET_OPTIONS.map((option) => {
+              const formKey = DIET_KEY_MAP[option.key];
+              return (
+                <View key={option.key} style={styles.switchRow}>
+                  <Text style={styles.switchLabel}>{option.label}</Text>
+                  <Switch
+                    value={data[formKey]}
+                    onValueChange={() => toggleDietFlag(formKey)}
+                    trackColor={{
+                      false: '#E5E7EB',
+                      true: `${Colors.light.primary}60`,
+                    }}
+                    thumbColor={data[formKey] ? Colors.light.primary : '#f4f3f4'}
+                  />
+                </View>
+              );
+            })}
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Include Cuisines</Text>
+            <Text style={styles.sectionHint}>Select cuisines you enjoy</Text>
+            <ChipSelect
+              options={ALL_CUISINES}
+              selected={data.includeCuisine}
+              onToggle={toggleIncludeCuisine}
+            />
+          </View>
+
+          <View style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>Exclude Cuisines</Text>
+            <Text style={styles.sectionHint}>Select cuisines to avoid</Text>
+            <ChipSelect
+              options={ALL_CUISINES}
+              selected={data.excludeCuisine}
+              onToggle={toggleExcludeCuisine}
+            />
+          </View>
+        </View>
+      </ScrollView>
+
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity
+          style={[styles.submitButton, loading && styles.submitButtonDisabled]}
+          onPress={handleSubmit}
+          disabled={loading}
+          activeOpacity={0.8}
+        >
+          {loading ? (
+            <ActivityIndicator color={Colors.light.surface} />
+          ) : (
+            <Text style={styles.submitButtonText}>Complete Profile</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.light.background,
+  },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 120,
+  },
+  progressContainer: {
+    marginBottom: 24,
+  },
+  progressBar: {
+    height: 4,
+    backgroundColor: Colors.light.surface,
+    borderRadius: 2,
+    marginBottom: 8,
+  },
+  progressFill: {
+    height: 4,
+    backgroundColor: Colors.light.primary,
+    borderRadius: 2,
+  },
+  progressText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.light.textMuted,
+  },
+  header: {
+    marginBottom: 32,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+    lineHeight: 22,
+  },
+  content: {
+    gap: 16,
+  },
+  sectionCard: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: Layout.cardRadius,
+    padding: 16,
+    gap: 12,
+    ...Shadows.card,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: 4,
+  },
+  sectionHint: {
+    fontSize: 13,
+    color: Colors.light.textMuted,
+    marginTop: -8,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 4,
+  },
+  switchLabel: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: Colors.light.text,
+  },
+  buttonContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: 20,
+    paddingBottom: 30,
+    backgroundColor: Colors.light.background,
+    borderTopWidth: 1,
+    borderTopColor: Colors.light.background,
+    ...Shadows.card,
+  },
+  submitButton: {
+    backgroundColor: Colors.light.primary,
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+    ...Shadows.card,
+  },
+  submitButtonDisabled: {
+    backgroundColor: Colors.light.textMuted,
+    opacity: 0.5,
+  },
+  submitButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.surface,
+  },
+});

--- a/frontend/app/onboarding/step6.tsx
+++ b/frontend/app/onboarding/step6.tsx
@@ -75,10 +75,7 @@ export default function Step6Screen() {
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
-      <ScrollView
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
-      >
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <View style={styles.progressContainer}>
           <View style={styles.progressBar}>
             <View style={[styles.progressFill, { width: '100%' }]} />

--- a/frontend/components/AlternativesModal.tsx
+++ b/frontend/components/AlternativesModal.tsx
@@ -1,8 +1,8 @@
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { Colors, Layout } from '@/constants/theme';
 import type { WeeklyScheduleItem } from '@/types/schedule';
-import { X } from 'lucide-react-native';
-import React from 'react';
-import { Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 type AlternativesModalProps = {
   visible: boolean;
@@ -19,6 +19,29 @@ export function AlternativesModal({
   alternatives,
   onSelect,
 }: AlternativesModalProps) {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['80%'], []);
+
+  useEffect(() => {
+    if (visible && item) {
+      bottomSheetRef.current?.present();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [visible, item]);
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
   if (!item) return null;
 
   const handleSelect = (alternative: WeeklyScheduleItem) => {
@@ -27,72 +50,51 @@ export function AlternativesModal({
   };
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
-      <View style={styles.overlay}>
-        <View style={styles.modalContainer}>
-          {/* Header */}
-          <View style={styles.header}>
-            <View>
-              <Text style={styles.headerTitle}>Swap Item</Text>
-              <Text style={styles.headerSubtitle}>Choose an alternative for {item.time}</Text>
-            </View>
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <X size={24} color={Colors.light.text} />
-            </TouchableOpacity>
-          </View>
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      backdropComponent={renderBackdrop}
+      onDismiss={onClose}
+    >
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Swap Item</Text>
+        <Text style={styles.headerSubtitle}>Choose an alternative for {item.time}</Text>
+      </View>
 
-          {/* Current Item */}
-          <View style={styles.currentSection}>
-            <Text style={styles.sectionTitle}>Current</Text>
-            <View style={styles.currentCard}>
-              <Text style={styles.currentTitle}>{item.title}</Text>
-              {item.subtitle && <Text style={styles.currentSubtitle}>{item.subtitle}</Text>}
-            </View>
-          </View>
-
-          {/* Alternatives */}
-          <ScrollView style={styles.alternativesContainer}>
-            <Text style={styles.sectionTitle}>Alternatives</Text>
-            {alternatives.map((alt, index) => (
-              <TouchableOpacity
-                key={alt.id || index}
-                style={styles.alternativeCard}
-                onPress={() => handleSelect(alt)}
-              >
-                <View style={styles.alternativeContent}>
-                  <Text style={styles.alternativeTitle}>{alt.title}</Text>
-                  {alt.subtitle && <Text style={styles.alternativeSubtitle}>{alt.subtitle}</Text>}
-                  <Text style={styles.alternativeDuration}>{alt.duration}</Text>
-                </View>
-                <View style={styles.selectButton}>
-                  <Text style={styles.selectButtonText}>Select</Text>
-                </View>
-              </TouchableOpacity>
-            ))}
-          </ScrollView>
+      <View style={styles.currentSection}>
+        <Text style={styles.sectionTitle}>Current</Text>
+        <View style={styles.currentCard}>
+          <Text style={styles.currentTitle}>{item.title}</Text>
+          {item.subtitle && <Text style={styles.currentSubtitle}>{item.subtitle}</Text>}
         </View>
       </View>
-    </Modal>
+
+      <BottomSheetScrollView contentContainerStyle={styles.alternativesContainer}>
+        <Text style={styles.sectionTitle}>Alternatives</Text>
+        {alternatives.map((alt, index) => (
+          <TouchableOpacity
+            key={alt.id || index}
+            style={styles.alternativeCard}
+            onPress={() => handleSelect(alt)}
+          >
+            <View style={styles.alternativeContent}>
+              <Text style={styles.alternativeTitle}>{alt.title}</Text>
+              {alt.subtitle && <Text style={styles.alternativeSubtitle}>{alt.subtitle}</Text>}
+              <Text style={styles.alternativeDuration}>{alt.duration}</Text>
+            </View>
+            <View style={styles.selectButton}>
+              <Text style={styles.selectButtonText}>Select</Text>
+            </View>
+          </TouchableOpacity>
+        ))}
+      </BottomSheetScrollView>
+    </BottomSheetModal>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'flex-end',
-  },
-  modalContainer: {
-    backgroundColor: Colors.light.background,
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: '80%',
-    paddingBottom: 40,
-  },
   header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
     padding: 20,
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
@@ -106,14 +108,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: Colors.light.textMuted,
     marginTop: 2,
-  },
-  closeButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: Colors.light.surface,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   currentSection: {
     padding: 20,
@@ -146,6 +140,7 @@ const styles = StyleSheet.create({
   },
   alternativesContainer: {
     paddingHorizontal: 20,
+    paddingBottom: 40,
   },
   alternativeCard: {
     backgroundColor: Colors.light.surface,

--- a/frontend/components/DatePickerInput.tsx
+++ b/frontend/components/DatePickerInput.tsx
@@ -1,8 +1,8 @@
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { Colors } from '@/constants/theme';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
-  Modal,
   Platform,
   StyleProp,
   StyleSheet,
@@ -27,7 +27,6 @@ function parseValue(value: string | null | undefined): Date {
     today.setHours(0, 0, 0, 0);
     return today;
   }
-  // format YYYY-MM-DD
   const [year, month, day] = value.split('-').map(Number);
   const d = new Date(year, month - 1, day);
   return isNaN(d.getTime()) ? new Date() : d;
@@ -53,26 +52,32 @@ export function DatePickerInput({
   error,
 }: DatePickerInputProps) {
   const currentDate = parseValue(value);
-  const [showPicker, setShowPicker] = useState(false);
-  const [tempDate, setTempDate] = useState(currentDate);
+  const [showAndroid, setShowAndroid] = useState(false);
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
 
   const open = () => {
-    setTempDate(parseValue(value));
-    setShowPicker(true);
-  };
-
-  const confirm = () => {
-    setShowPicker(false);
-    onChange(formatOutput(tempDate));
-  };
-
-  const cancel = () => {
-    setShowPicker(false);
+    if (Platform.OS === 'android') {
+      setShowAndroid(true);
+      return;
+    }
+    bottomSheetRef.current?.present();
   };
 
   const clear = () => {
     onChange('');
   };
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
 
   return (
     <View style={style}>
@@ -91,40 +96,32 @@ export function DatePickerInput({
       </View>
       {error && <Text style={styles.errorText}>{error}</Text>}
 
-      {Platform.OS === 'ios' && showPicker && (
-        <Modal transparent animationType="slide">
-          <View style={styles.modalOverlay}>
-            <View style={styles.pickerContainer}>
-              <View style={styles.pickerHeader}>
-                <TouchableOpacity onPress={cancel}>
-                  <Text style={styles.pickerHeaderCancel}>Cancel</Text>
-                </TouchableOpacity>
-                <TouchableOpacity onPress={confirm}>
-                  <Text style={styles.pickerHeaderDone}>Done</Text>
-                </TouchableOpacity>
-              </View>
-              <DateTimePicker
-                value={tempDate}
-                mode="date"
-                display="spinner"
-                textColor="black"
-                themeVariant="light"
-                minimumDate={minimumDate}
-                onChange={(_, date) => setTempDate(date ?? tempDate)}
-              />
-            </View>
+      <BottomSheetModal ref={bottomSheetRef} enableDynamicSizing backdropComponent={renderBackdrop}>
+        <BottomSheetView style={styles.sheetContent}>
+          <View style={styles.pickerWrapper}>
+            <DateTimePicker
+              value={currentDate}
+              mode="date"
+              display="spinner"
+              textColor="black"
+              themeVariant="light"
+              minimumDate={minimumDate}
+              onChange={(_, date) => {
+                if (date) onChange(formatOutput(date));
+              }}
+            />
           </View>
-        </Modal>
-      )}
+        </BottomSheetView>
+      </BottomSheetModal>
 
-      {Platform.OS === 'android' && showPicker && (
+      {Platform.OS === 'android' && showAndroid && (
         <DateTimePicker
           value={currentDate}
           mode="date"
           display="default"
           minimumDate={minimumDate}
           onChange={(_, date) => {
-            setShowPicker(false);
+            setShowAndroid(false);
             if (date) onChange(formatOutput(date));
           }}
         />
@@ -177,35 +174,11 @@ const styles = StyleSheet.create({
     color: Colors.light.textMuted,
     lineHeight: 22,
   },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
-    backgroundColor: 'rgba(0,0,0,0.4)',
-  },
-  pickerContainer: {
-    backgroundColor: Colors.light.surface,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+  sheetContent: {
     paddingBottom: 30,
+  },
+  pickerWrapper: {
     alignItems: 'center',
-  },
-  pickerHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
-    alignSelf: 'stretch',
-  },
-  pickerHeaderCancel: {
-    fontSize: 16,
-    color: Colors.light.textMuted,
-  },
-  pickerHeaderDone: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: Colors.light.primary,
   },
   errorText: {
     fontSize: 13,

--- a/frontend/components/DatePickerInput.tsx
+++ b/frontend/components/DatePickerInput.tsx
@@ -17,6 +17,8 @@ interface DatePickerInputProps {
   value: string;
   onChange: (v: string) => void;
   style?: StyleProp<ViewStyle>;
+  minimumDate?: Date;
+  error?: string;
 }
 
 function parseValue(value: string | null | undefined): Date {
@@ -42,7 +44,14 @@ function displayDate(value: string): string {
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 }
 
-export function DatePickerInput({ label, value, onChange, style }: DatePickerInputProps) {
+export function DatePickerInput({
+  label,
+  value,
+  onChange,
+  style,
+  minimumDate,
+  error,
+}: DatePickerInputProps) {
   const currentDate = parseValue(value);
   const [showPicker, setShowPicker] = useState(false);
   const [tempDate, setTempDate] = useState(currentDate);
@@ -80,6 +89,7 @@ export function DatePickerInput({ label, value, onChange, style }: DatePickerInp
           </TouchableOpacity>
         ) : null}
       </View>
+      {error && <Text style={styles.errorText}>{error}</Text>}
 
       {Platform.OS === 'ios' && showPicker && (
         <Modal transparent animationType="slide">
@@ -99,6 +109,7 @@ export function DatePickerInput({ label, value, onChange, style }: DatePickerInp
                 display="spinner"
                 textColor="black"
                 themeVariant="light"
+                minimumDate={minimumDate}
                 onChange={(_, date) => setTempDate(date ?? tempDate)}
               />
             </View>
@@ -111,6 +122,7 @@ export function DatePickerInput({ label, value, onChange, style }: DatePickerInp
           value={currentDate}
           mode="date"
           display="default"
+          minimumDate={minimumDate}
           onChange={(_, date) => {
             setShowPicker(false);
             if (date) onChange(formatOutput(date));
@@ -175,6 +187,7 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
     paddingBottom: 30,
+    alignItems: 'center',
   },
   pickerHeader: {
     flexDirection: 'row',
@@ -183,6 +196,7 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
+    alignSelf: 'stretch',
   },
   pickerHeaderCancel: {
     fontSize: 16,
@@ -192,5 +206,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: Colors.light.primary,
+  },
+  errorText: {
+    fontSize: 13,
+    color: Colors.light.error,
+    marginTop: 4,
   },
 });

--- a/frontend/components/EditItemModal.tsx
+++ b/frontend/components/EditItemModal.tsx
@@ -1,19 +1,9 @@
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { Colors } from '@/constants/theme';
 import type { ItemType, WeeklyScheduleItem } from '@/types/schedule';
 import { TimePickerInput } from '@/components/TimePickerInput';
-import { X } from 'lucide-react-native';
-import React, { useState } from 'react';
-import {
-  KeyboardAvoidingView,
-  Modal,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 type EditItemModalProps = {
   visible: boolean;
@@ -40,7 +30,25 @@ export function EditItemModal({
   const [workoutType, setWorkoutType] = useState(item?.workoutType || '');
   const [targetHours, setTargetHours] = useState(item?.targetHours?.toString() || '8');
 
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['90%'], []);
+
   const currentType = item?.type || itemType;
+
+  useEffect(() => {
+    if (visible) {
+      setTime(item?.time || '7:00 AM');
+      setTitle(item?.title || '');
+      setSubtitle(item?.subtitle || '');
+      setDuration(item?.duration || '30 min');
+      setCalories(item?.calories?.toString() || '');
+      setWorkoutType(item?.workoutType || '');
+      setTargetHours(item?.targetHours?.toString() || '8');
+      bottomSheetRef.current?.present();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [visible, item]);
 
   const handleSave = () => {
     const baseItem = {
@@ -75,164 +83,142 @@ export function EditItemModal({
     onClose();
   };
 
-  // Reset form when modal opens
-  React.useEffect(() => {
-    if (visible) {
-      setTime(item?.time || '7:00 AM');
-      setTitle(item?.title || '');
-      setSubtitle(item?.subtitle || '');
-      setDuration(item?.duration || '30 min');
-      setCalories(item?.calories?.toString() || '');
-      setWorkoutType(item?.workoutType || '');
-      setTargetHours(item?.targetHours?.toString() || '8');
-    }
-  }, [visible, item]);
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.overlay}
-      >
-        <View style={styles.modalContainer}>
-          {/* Header */}
-          <View style={styles.header}>
-            <View>
-              <Text style={styles.headerTitle}>{mode === 'edit' ? 'Edit Item' : 'Add Item'}</Text>
-              <Text style={styles.headerSubtitle}>
-                {currentType === 'meal'
-                  ? 'Meal details'
-                  : currentType === 'workout'
-                    ? 'Workout details'
-                    : 'Sleep details'}
-              </Text>
-            </View>
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <X size={24} color={Colors.light.text} />
-            </TouchableOpacity>
-          </View>
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      backdropComponent={renderBackdrop}
+      onDismiss={onClose}
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+      android_keyboardInputMode="adjustResize"
+    >
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>{mode === 'edit' ? 'Edit Item' : 'Add Item'}</Text>
+        <Text style={styles.headerSubtitle}>
+          {currentType === 'meal'
+            ? 'Meal details'
+            : currentType === 'workout'
+              ? 'Workout details'
+              : 'Sleep details'}
+        </Text>
+      </View>
 
-          {/* Form */}
-          <ScrollView style={styles.form}>
-            <View style={styles.field}>
-              <TimePickerInput label="Time" value={time} onChange={setTime} format="12h" />
-            </View>
-
-            <View style={styles.field}>
-              <Text style={styles.label}>Title</Text>
-              <TextInput
-                style={styles.input}
-                value={title}
-                onChangeText={setTitle}
-                placeholder={
-                  currentType === 'meal'
-                    ? 'e.g., Greek Yogurt Bowl'
-                    : currentType === 'workout'
-                      ? 'e.g., HIIT Training'
-                      : 'Sleep'
-                }
-                placeholderTextColor={Colors.light.textMuted}
-              />
-            </View>
-
-            {currentType === 'meal' && (
-              <>
-                <View style={styles.field}>
-                  <Text style={styles.label}>Description</Text>
-                  <TextInput
-                    style={styles.input}
-                    value={subtitle}
-                    onChangeText={setSubtitle}
-                    placeholder="e.g., with berries and granola"
-                    placeholderTextColor={Colors.light.textMuted}
-                  />
-                </View>
-
-                <View style={styles.field}>
-                  <Text style={styles.label}>Calories</Text>
-                  <TextInput
-                    style={styles.input}
-                    value={calories}
-                    onChangeText={setCalories}
-                    placeholder="e.g., 380"
-                    keyboardType="numeric"
-                    placeholderTextColor={Colors.light.textMuted}
-                  />
-                </View>
-              </>
-            )}
-
-            {currentType === 'workout' && (
-              <View style={styles.field}>
-                <Text style={styles.label}>Workout Type</Text>
-                <TextInput
-                  style={styles.input}
-                  value={workoutType}
-                  onChangeText={setWorkoutType}
-                  placeholder="e.g., HIIT, Strength, Yoga"
-                  placeholderTextColor={Colors.light.textMuted}
-                />
-              </View>
-            )}
-
-            {currentType === 'sleep' && (
-              <View style={styles.field}>
-                <Text style={styles.label}>Target Hours</Text>
-                <TextInput
-                  style={styles.input}
-                  value={targetHours}
-                  onChangeText={setTargetHours}
-                  placeholder="e.g., 8"
-                  keyboardType="decimal-pad"
-                  placeholderTextColor={Colors.light.textMuted}
-                />
-              </View>
-            )}
-
-            <View style={styles.field}>
-              <Text style={styles.label}>Duration</Text>
-              <TextInput
-                style={styles.input}
-                value={duration}
-                onChangeText={setDuration}
-                placeholder="e.g., 30 min"
-                placeholderTextColor={Colors.light.textMuted}
-              />
-            </View>
-          </ScrollView>
-
-          {/* Actions */}
-          <View style={styles.actions}>
-            <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
-              <Text style={styles.cancelButtonText}>Cancel</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
-              <Text style={styles.saveButtonText}>Save</Text>
-            </TouchableOpacity>
-          </View>
+      <BottomSheetScrollView contentContainerStyle={styles.form}>
+        <View style={styles.field}>
+          <TimePickerInput label="Time" value={time} onChange={setTime} format="12h" />
         </View>
-      </KeyboardAvoidingView>
-    </Modal>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Title</Text>
+          <TextInput
+            style={styles.input}
+            value={title}
+            onChangeText={setTitle}
+            placeholder={
+              currentType === 'meal'
+                ? 'e.g., Greek Yogurt Bowl'
+                : currentType === 'workout'
+                  ? 'e.g., HIIT Training'
+                  : 'Sleep'
+            }
+            placeholderTextColor={Colors.light.textMuted}
+          />
+        </View>
+
+        {currentType === 'meal' && (
+          <>
+            <View style={styles.field}>
+              <Text style={styles.label}>Description</Text>
+              <TextInput
+                style={styles.input}
+                value={subtitle}
+                onChangeText={setSubtitle}
+                placeholder="e.g., with berries and granola"
+                placeholderTextColor={Colors.light.textMuted}
+              />
+            </View>
+
+            <View style={styles.field}>
+              <Text style={styles.label}>Calories</Text>
+              <TextInput
+                style={styles.input}
+                value={calories}
+                onChangeText={setCalories}
+                placeholder="e.g., 380"
+                keyboardType="numeric"
+                placeholderTextColor={Colors.light.textMuted}
+              />
+            </View>
+          </>
+        )}
+
+        {currentType === 'workout' && (
+          <View style={styles.field}>
+            <Text style={styles.label}>Workout Type</Text>
+            <TextInput
+              style={styles.input}
+              value={workoutType}
+              onChangeText={setWorkoutType}
+              placeholder="e.g., HIIT, Strength, Yoga"
+              placeholderTextColor={Colors.light.textMuted}
+            />
+          </View>
+        )}
+
+        {currentType === 'sleep' && (
+          <View style={styles.field}>
+            <Text style={styles.label}>Target Hours</Text>
+            <TextInput
+              style={styles.input}
+              value={targetHours}
+              onChangeText={setTargetHours}
+              placeholder="e.g., 8"
+              keyboardType="decimal-pad"
+              placeholderTextColor={Colors.light.textMuted}
+            />
+          </View>
+        )}
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Duration</Text>
+          <TextInput
+            style={styles.input}
+            value={duration}
+            onChangeText={setDuration}
+            placeholder="e.g., 30 min"
+            placeholderTextColor={Colors.light.textMuted}
+          />
+        </View>
+      </BottomSheetScrollView>
+
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
+          <Text style={styles.cancelButtonText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+          <Text style={styles.saveButtonText}>Save</Text>
+        </TouchableOpacity>
+      </View>
+    </BottomSheetModal>
   );
 }
 
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'flex-end',
-  },
-  modalContainer: {
-    backgroundColor: Colors.light.background,
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: '90%',
-    paddingBottom: 40,
-  },
   header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
     padding: 20,
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
@@ -246,14 +232,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: Colors.light.textMuted,
     marginTop: 2,
-  },
-  closeButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: Colors.light.surface,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   form: {
     padding: 20,
@@ -281,6 +259,7 @@ const styles = StyleSheet.create({
     gap: 12,
     paddingHorizontal: 20,
     paddingTop: 12,
+    paddingBottom: 40,
   },
   cancelButton: {
     flex: 1,

--- a/frontend/components/MealDetailModal.tsx
+++ b/frontend/components/MealDetailModal.tsx
@@ -1,8 +1,9 @@
 import type { Recipe } from '@/api/types.gen';
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { Colors } from '@/constants/theme';
 import { ArrowRight, Edit, Trash2 } from 'lucide-react-native';
-import React from 'react';
-import { Linking, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 interface MealData {
   time: string;
@@ -28,6 +29,29 @@ export const MealDetailModal = ({
   onModify,
   onRemove,
 }: MealDetailModalProps) => {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['85%'], []);
+
+  useEffect(() => {
+    if (visible && meal) {
+      bottomSheetRef.current?.present();
+    } else {
+      bottomSheetRef.current?.dismiss();
+    }
+  }, [visible, meal]);
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
   if (!meal) return null;
 
   const recipe = meal.recipe;
@@ -38,139 +62,106 @@ export const MealDetailModal = ({
   const prepTime = recipe?.preparation_time_minutes;
 
   return (
-    <Modal animationType="slide" transparent={true} visible={visible} onRequestClose={onClose}>
-      <View style={styles.centeredView}>
-        <TouchableOpacity style={styles.backdrop} onPress={onClose} activeOpacity={1} />
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      backdropComponent={renderBackdrop}
+      onDismiss={onClose}
+    >
+      <BottomSheetScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.subtitle}>
+          Scheduled for {meal.time}
+          {prepTime ? ` · ${prepTime} min prep` : ''}
+        </Text>
 
-        <View style={styles.modalView}>
-          <View style={styles.dragHandle} />
-
-          <ScrollView contentContainerStyle={{ paddingBottom: 40 }}>
-            <Text style={styles.title}>{title}</Text>
-            <Text style={styles.subtitle}>
-              Scheduled for {meal.time}
-              {prepTime ? ` · ${prepTime} min prep` : ''}
-            </Text>
-
-            {/* Macros */}
-            {nutrients && (
-              <View style={styles.sectionBox}>
-                <Text style={styles.sectionHeader}>MACRONUTRIENTS</Text>
-                <View style={styles.macrosGrid}>
-                  <View style={styles.macroItem}>
-                    <Text style={styles.macroValue}>{nutrients.calories}</Text>
-                    <Text style={styles.macroLabel}>Calories</Text>
-                  </View>
-                  <View style={styles.macroItem}>
-                    <Text style={[styles.macroValue, { color: Colors.light.primary }]}>
-                      {nutrients.protein}g
-                    </Text>
-                    <Text style={styles.macroLabel}>Protein</Text>
-                  </View>
-                  <View style={styles.macroItem}>
-                    <Text style={[styles.macroValue, { color: Colors.light.charts.carbs }]}>
-                      {nutrients.carbohydrates}g
-                    </Text>
-                    <Text style={styles.macroLabel}>Carbs</Text>
-                  </View>
-                  <View style={styles.macroItem}>
-                    <Text style={[styles.macroValue, { color: Colors.light.charts.fats }]}>
-                      {nutrients.fat}g
-                    </Text>
-                    <Text style={styles.macroLabel}>Fats</Text>
-                  </View>
-                </View>
+        {nutrients && (
+          <View style={styles.sectionBox}>
+            <Text style={styles.sectionHeader}>MACRONUTRIENTS</Text>
+            <View style={styles.macrosGrid}>
+              <View style={styles.macroItem}>
+                <Text style={styles.macroValue}>{nutrients.calories}</Text>
+                <Text style={styles.macroLabel}>Calories</Text>
               </View>
-            )}
-
-            {/* Ingredients */}
-            {ingredients.length > 0 && (
-              <View style={{ marginBottom: 24 }}>
-                <Text style={[styles.sectionHeader, { marginBottom: 12 }]}>INGREDIENTS</Text>
-                <View style={{ marginLeft: 8 }}>
-                  {ingredients.map((ing, i) => (
-                    <Text key={i} style={styles.ingredientItem}>
-                      • {ing}
-                    </Text>
-                  ))}
-                </View>
+              <View style={styles.macroItem}>
+                <Text style={[styles.macroValue, { color: Colors.light.primary }]}>
+                  {nutrients.protein}g
+                </Text>
+                <Text style={styles.macroLabel}>Protein</Text>
               </View>
-            )}
-
-            {/* Source Link */}
-            {sourceUrl && (
-              <TouchableOpacity style={styles.linkCard} onPress={() => Linking.openURL(sourceUrl)}>
-                <View style={{ flex: 1 }}>
-                  <Text style={styles.linkSubtitle}>VIEW RECIPE</Text>
-                  <Text style={styles.linkTitle} numberOfLines={1}>
-                    {new URL(sourceUrl).hostname.replace('www.', '')}
-                  </Text>
-                </View>
-                <ArrowRight size={20} color={Colors.light.primary} />
-              </TouchableOpacity>
-            )}
-
-            {/* Actions */}
-            <View style={styles.actionsRow}>
-              <TouchableOpacity
-                style={[styles.actionButton, { backgroundColor: Colors.light.background, flex: 1 }]}
-                onPress={() => {
-                  onModify?.(meal);
-                  onClose();
-                }}
-              >
-                <Edit size={20} color={Colors.light.text} />
-                <Text style={[styles.actionButtonText, { color: Colors.light.text }]}>Modify</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.actionButton, { backgroundColor: `${Colors.light.error}15` }]}
-                onPress={() => {
-                  onRemove?.(meal);
-                  onClose();
-                }}
-              >
-                <Trash2 size={20} color={Colors.light.error} />
-                <Text style={[styles.actionButtonText, { color: Colors.light.error }]}>Remove</Text>
-              </TouchableOpacity>
+              <View style={styles.macroItem}>
+                <Text style={[styles.macroValue, { color: Colors.light.charts.carbs }]}>
+                  {nutrients.carbohydrates}g
+                </Text>
+                <Text style={styles.macroLabel}>Carbs</Text>
+              </View>
+              <View style={styles.macroItem}>
+                <Text style={[styles.macroValue, { color: Colors.light.charts.fats }]}>
+                  {nutrients.fat}g
+                </Text>
+                <Text style={styles.macroLabel}>Fats</Text>
+              </View>
             </View>
-          </ScrollView>
+          </View>
+        )}
+
+        {ingredients.length > 0 && (
+          <View style={{ marginBottom: 24 }}>
+            <Text style={[styles.sectionHeader, { marginBottom: 12 }]}>INGREDIENTS</Text>
+            <View style={{ marginLeft: 8 }}>
+              {ingredients.map((ing, i) => (
+                <Text key={i} style={styles.ingredientItem}>
+                  • {ing}
+                </Text>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {sourceUrl && (
+          <TouchableOpacity style={styles.linkCard} onPress={() => Linking.openURL(sourceUrl)}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.linkSubtitle}>VIEW RECIPE</Text>
+              <Text style={styles.linkTitle} numberOfLines={1}>
+                {new URL(sourceUrl).hostname.replace('www.', '')}
+              </Text>
+            </View>
+            <ArrowRight size={20} color={Colors.light.primary} />
+          </TouchableOpacity>
+        )}
+
+        <View style={styles.actionsRow}>
+          <TouchableOpacity
+            style={[styles.actionButton, { backgroundColor: Colors.light.background, flex: 1 }]}
+            onPress={() => {
+              onModify?.(meal);
+              onClose();
+            }}
+          >
+            <Edit size={20} color={Colors.light.text} />
+            <Text style={[styles.actionButtonText, { color: Colors.light.text }]}>Modify</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.actionButton, { backgroundColor: `${Colors.light.error}15` }]}
+            onPress={() => {
+              onRemove?.(meal);
+              onClose();
+            }}
+          >
+            <Trash2 size={20} color={Colors.light.error} />
+            <Text style={[styles.actionButtonText, { color: Colors.light.error }]}>Remove</Text>
+          </TouchableOpacity>
         </View>
-      </View>
-    </Modal>
+      </BottomSheetScrollView>
+    </BottomSheetModal>
   );
 };
 
 const styles = StyleSheet.create({
-  centeredView: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-  },
-  modalView: {
-    backgroundColor: Colors.light.surface,
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
+  scrollContent: {
     padding: 24,
-    maxHeight: '85%',
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: -2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
-    elevation: 5,
-  },
-  dragHandle: {
-    width: 40,
-    height: 4,
-    backgroundColor: Colors.light.background,
-    borderRadius: 2,
-    alignSelf: 'center',
-    marginBottom: 24,
+    paddingBottom: 40,
   },
   title: {
     fontSize: 24,

--- a/frontend/components/TimePickerInput.tsx
+++ b/frontend/components/TimePickerInput.tsx
@@ -213,6 +213,7 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
     paddingBottom: 30,
+    alignItems: 'center',
   },
   pickerHeader: {
     flexDirection: 'row',
@@ -221,6 +222,7 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
+    alignSelf: 'stretch',
   },
   pickerHeaderCancel: {
     fontSize: 16,

--- a/frontend/components/TimePickerInput.tsx
+++ b/frontend/components/TimePickerInput.tsx
@@ -1,9 +1,9 @@
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { Colors } from '@/constants/theme';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   Alert,
-  Modal,
   Platform,
   StyleProp,
   StyleSheet,
@@ -41,7 +41,6 @@ function parseValue(value: string, format: '24h' | '12h'): Date {
       }
     }
   } else {
-    // "h:mm AM/PM"
     const match = value.match(/^(\d+):(\d+)\s*(AM|PM)$/i);
     if (match) {
       let h = parseInt(match[1], 10);
@@ -80,12 +79,15 @@ export function TimePickerInput({
   maxTime,
 }: TimePickerInputProps) {
   const currentDate = parseValue(value, format);
-  const [showPicker, setShowPicker] = useState(false);
-  const [tempDate, setTempDate] = useState(currentDate);
+  const [showAndroid, setShowAndroid] = useState(false);
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
 
   const open = () => {
-    setTempDate(parseValue(value, format));
-    setShowPicker(true);
+    if (Platform.OS === 'android') {
+      setShowAndroid(true);
+      return;
+    }
+    bottomSheetRef.current?.present();
   };
 
   const minDate = React.useMemo(
@@ -97,9 +99,9 @@ export function TimePickerInput({
     [maxTime, format]
   );
 
-  const confirm = () => {
-    setShowPicker(false);
-    const result = formatOutput(tempDate, format);
+  const handleChange = (_: unknown, date?: Date) => {
+    if (!date) return;
+    const result = formatOutput(date, format);
 
     if (minTime || maxTime) {
       const resultMins = timeToMins(result);
@@ -116,9 +118,17 @@ export function TimePickerInput({
     onChange(result);
   };
 
-  const cancel = () => {
-    setShowPicker(false);
-  };
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
 
   return (
     <View style={style}>
@@ -129,49 +139,31 @@ export function TimePickerInput({
         </Text>
       </TouchableOpacity>
 
-      {Platform.OS === 'ios' && showPicker && (
-        <Modal transparent animationType="slide">
-          <View style={styles.modalOverlay}>
-            <View style={styles.pickerContainer}>
-              <View style={styles.pickerHeader}>
-                <TouchableOpacity onPress={cancel}>
-                  <Text style={styles.pickerHeaderCancel}>Cancel</Text>
-                </TouchableOpacity>
-                <TouchableOpacity onPress={confirm}>
-                  <Text style={styles.pickerHeaderDone}>Done</Text>
-                </TouchableOpacity>
-              </View>
-              <DateTimePicker
-                value={tempDate}
-                mode="time"
-                display="spinner"
-                textColor="black"
-                themeVariant="light"
-                minimumDate={minDate}
-                maximumDate={maxDate}
-                onChange={(_, date) => {
-                  if (
-                    date &&
-                    (date.getHours() !== tempDate.getHours() ||
-                      date.getMinutes() !== tempDate.getMinutes())
-                  ) {
-                    setTempDate(date);
-                  }
-                }}
-              />
-            </View>
+      <BottomSheetModal ref={bottomSheetRef} enableDynamicSizing backdropComponent={renderBackdrop}>
+        <BottomSheetView style={styles.sheetContent}>
+          <View style={styles.pickerWrapper}>
+            <DateTimePicker
+              value={currentDate}
+              mode="time"
+              display="spinner"
+              textColor="black"
+              themeVariant="light"
+              minimumDate={minDate}
+              maximumDate={maxDate}
+              onChange={handleChange}
+            />
           </View>
-        </Modal>
-      )}
+        </BottomSheetView>
+      </BottomSheetModal>
 
-      {Platform.OS === 'android' && showPicker && (
+      {Platform.OS === 'android' && showAndroid && (
         <DateTimePicker
           value={currentDate}
           mode="time"
           is24Hour={false}
           display="default"
           onChange={(_, date) => {
-            setShowPicker(false);
+            setShowAndroid(false);
             if (date) onChange(formatOutput(date, format));
           }}
         />
@@ -203,34 +195,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: Colors.light.textMuted,
   },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
-    backgroundColor: 'rgba(0,0,0,0.4)',
-  },
-  pickerContainer: {
-    backgroundColor: Colors.light.surface,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+  sheetContent: {
     paddingBottom: 30,
+  },
+  pickerWrapper: {
     alignItems: 'center',
-  },
-  pickerHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
-    alignSelf: 'stretch',
-  },
-  pickerHeaderCancel: {
-    fontSize: 16,
-    color: Colors.light.textMuted,
-  },
-  pickerHeaderDone: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: Colors.light.primary,
   },
 });

--- a/frontend/hooks/useOnboarding.tsx
+++ b/frontend/hooks/useOnboarding.tsx
@@ -212,9 +212,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
 
   const isSection5Complete = () => {
     const targetWeightKg = parseFloat(data.targetWeight);
-    return (
-      !isNaN(targetWeightKg) && targetWeightKg > 0 && data.targetDate !== ''
-    );
+    return !isNaN(targetWeightKg) && targetWeightKg > 0 && data.targetDate !== '';
   };
 
   const isSection6Complete = () => {

--- a/frontend/hooks/useOnboarding.tsx
+++ b/frontend/hooks/useOnboarding.tsx
@@ -1,4 +1,11 @@
-import type { ActivityLevel, PregnancyStatus, Sex, UserCreate } from '@/api/types.gen';
+import type {
+  ActivityLevel,
+  Allergy,
+  Cuisine,
+  PregnancyStatus,
+  Sex,
+  UserCreate,
+} from '@/api/types.gen';
 import { VALIDATION_RULES } from '@/constants/onboarding';
 import { useUser } from '@/contexts/UserContext';
 import { createUser } from '@/lib/api-client';
@@ -14,8 +21,17 @@ export interface OnboardingData {
   pregnancyStatus?: PregnancyStatus;
   activityLevel: ActivityLevel | null;
   targetWeight: string; // kg (stored in metric regardless of display)
+  targetDate: string; // YYYY-MM-DD
   wakeUpTime: string; // HH:MM
   sleepTime: string; // HH:MM
+  allergies: Allergy[];
+  includeCuisine: Cuisine[];
+  excludeCuisine: Cuisine[];
+  isGlutenFree: boolean;
+  isKetogenic: boolean;
+  isVegetarian: boolean;
+  isVegan: boolean;
+  isPescatarian: boolean;
 }
 
 interface ValidationErrors {
@@ -24,6 +40,8 @@ interface ValidationErrors {
   height?: string;
   gender?: string;
   activityLevel?: string;
+  targetWeight?: string;
+  targetDate?: string;
 }
 
 interface OnboardingContextType {
@@ -39,6 +57,7 @@ interface OnboardingContextType {
   isSection3Complete: () => boolean;
   isSection4Complete: () => boolean;
   isSection5Complete: () => boolean;
+  isSection6Complete: () => boolean;
   canSubmit: () => boolean;
 }
 
@@ -58,8 +77,17 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     pregnancyStatus: undefined,
     activityLevel: null,
     targetWeight: '',
+    targetDate: '',
     wakeUpTime: '07:00',
     sleepTime: '23:00',
+    allergies: [],
+    includeCuisine: [],
+    excludeCuisine: [],
+    isGlutenFree: false,
+    isKetogenic: false,
+    isVegetarian: false,
+    isVegan: false,
+    isPescatarian: false,
   });
 
   const [errors, setErrors] = useState<ValidationErrors>({});
@@ -143,6 +171,15 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
       newErrors.activityLevel = 'Activity level is required';
     }
 
+    const targetWeightKg = parseFloat(data.targetWeight);
+    if (!data.targetWeight || isNaN(targetWeightKg) || targetWeightKg <= 0) {
+      newErrors.targetWeight = 'Target weight is required';
+    }
+
+    if (!data.targetDate) {
+      newErrors.targetDate = 'Target date is required';
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -174,13 +211,24 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
   };
 
   const isSection5Complete = () => {
-    // All fields are optional/pre-filled, so always complete
+    const targetWeightKg = parseFloat(data.targetWeight);
+    return (
+      !isNaN(targetWeightKg) && targetWeightKg > 0 && data.targetDate !== ''
+    );
+  };
+
+  const isSection6Complete = () => {
+    // All dietary fields are optional
     return true;
   };
 
   const canSubmit = () => {
     return (
-      isSection1Complete() && isSection2Complete() && isSection3Complete() && isSection4Complete()
+      isSection1Complete() &&
+      isSection2Complete() &&
+      isSection3Complete() &&
+      isSection4Complete() &&
+      isSection5Complete()
     );
   };
 
@@ -219,11 +267,11 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         payload.pregnancy_status = data.pregnancyStatus;
       }
 
-      // Include target weight if provided
-      const targetWeightKg = parseFloat(data.targetWeight);
-      if (!isNaN(targetWeightKg) && targetWeightKg > 0) {
-        payload.target_weight = targetWeightKg;
-      }
+      // Include target weight (now required)
+      payload.target_weight = parseFloat(data.targetWeight);
+
+      // Include target date (now required)
+      payload.target_date = data.targetDate;
 
       // Include wake/sleep times
       if (data.wakeUpTime) {
@@ -232,6 +280,22 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
       if (data.sleepTime) {
         payload.sleep_time = `${data.sleepTime}:00`;
       }
+
+      // Include dietary preferences
+      if (data.allergies.length > 0) {
+        payload.allergies = data.allergies;
+      }
+      if (data.includeCuisine.length > 0) {
+        payload.include_cuisine = data.includeCuisine;
+      }
+      if (data.excludeCuisine.length > 0) {
+        payload.exclude_cuisine = data.excludeCuisine;
+      }
+      payload.is_gluten_free = data.isGlutenFree;
+      payload.is_ketogenic = data.isKetogenic;
+      payload.is_vegetarian = data.isVegetarian;
+      payload.is_vegan = data.isVegan;
+      payload.is_pescatarian = data.isPescatarian;
 
       await createUser(payload, token);
 
@@ -261,6 +325,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     isSection3Complete,
     isSection4Complete,
     isSection5Complete,
+    isSection6Complete,
     canSubmit,
   };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@clerk/expo": "^3.1.4",
     "@expo/vector-icons": "^15.0.3",
+    "@gorhom/bottom-sheet": "^5.2.8",
     "@react-native-async-storage/async-storage": "~2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.4.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.0.3(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      '@gorhom/bottom-sheet':
+        specifier: ^5.2.8
+        version: 5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
       '@react-native-async-storage/async-storage':
         specifier: ~2.2.0
         version: 2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))
@@ -905,6 +908,27 @@ packages:
   '@expo/xcpretty@4.4.0':
     resolution: {integrity: sha512-o2qDlTqJ606h4xR36H2zWTywmZ3v3842K6TU8Ik2n1mfW0S580VHlt3eItVYdLYz+klaPp7CXqanja8eASZjRw==}
     hasBin: true
+
+  '@gorhom/bottom-sheet@5.2.8':
+    resolution: {integrity: sha512-+N27SMpbBxXZQ/IA2nlEV6RGxL/qSFHKfdFKcygvW+HqPG5jVNb1OqehLQsGfBP+Up42i0gW5ppI+DhpB7UCzA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-native': '*'
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>=2.16.1'
+      react-native-reanimated: '>=3.16.0 || >=4.0.0-'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-native':
+        optional: true
+
+  '@gorhom/portal@1.0.14':
+    resolution: {integrity: sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   '@hey-api/codegen-core@0.6.1':
     resolution: {integrity: sha512-khTIpxhKEAqmRmeLUnAFJQs4Sbg9RPokovJk9rRcC8B5MWH1j3/BRSqfpAIiJUBDU1+nbVg2RVCV+eQ174cdvw==}
@@ -6792,6 +6816,23 @@ snapshots:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
       js-yaml: 4.1.1
+
+  '@gorhom/bottom-sheet@5.2.8(@types/react@19.1.17)(react-native-gesture-handler@2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+    dependencies:
+      '@gorhom/portal': 1.0.14(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+      react-native-reanimated: 4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@gorhom/portal@1.0.14(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10))(react@19.1.0)':
+    dependencies:
+      nanoid: 3.3.11
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@5.0.10)
 
   '@hey-api/codegen-core@0.6.1(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Consolidates user profile setup into onboarding so freshly signed-up users land in a usable state. Before this, target weight, target date, and dietary preferences lived on separate profile screens, which meant the week planning flow hit a "Complete Your Profile" blocker the first time new users opened the app.

This PR adds a dietary preferences step to the onboarding flow (allergies, diet type, include and exclude cuisine), makes target weight and target date required in the existing profile step, and bumps every progress indicator to "Step X of 6". Profile edit screens remain available for post-onboarding edits.

Along the way, all modals across the app were migrated to @gorhom/bottom-sheet so backdrop fade, sheet slide-up animation, swipe-to-dismiss, and keyboard handling are consistent instead of implemented ad hoc per modal. Redundant Cancel/Done headers, custom drag handles, and X close buttons were removed since the native spinners auto-apply and the sheet handles dismissal. A sign-out button was added to the onboarding welcome screen so users can bail out of the wrong account.

## Relationship to other work

Uses the DatePickerInput and TimePickerInput components introduced in #172 for the target date popup. Follows the Clerk v3 migration in #181, which changed the authenticated landing path that onboarding routes into. Complements the welcome screen added in #220.

## Issues

Closes #213
