### PR TITLE
feat: add welcome screen before login

### DIFF
--- a/frontend/__tests__/screens/welcome.test.tsx
+++ b/frontend/__tests__/screens/welcome.test.tsx
@@ -38,7 +38,7 @@ describe('WelcomeScreen', () => {
 
     fireEvent.press(screen.getByText('Get Started'));
 
-    expect(router.push).toHaveBeenCalledWith('/(auth)/sign-in');
+    expect(router.replace).toHaveBeenCalledWith('/(auth)/sign-in');
   });
 
   it('redirects to auth if already signed in', () => {

--- a/frontend/__tests__/screens/welcome.test.tsx
+++ b/frontend/__tests__/screens/welcome.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { router, Redirect } from 'expo-router';
+import WelcomeScreen from '@/app/welcome';
+
+// Override the global Clerk mock to allow per-test control of useAuth
+jest.mock('@clerk/expo', () => ({
+  useAuth: jest.fn(() => ({
+    isSignedIn: false,
+    isLoaded: true,
+  })),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children,
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+import { useAuth } from '@clerk/expo';
+
+describe('WelcomeScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: not signed in, Clerk loaded
+    (useAuth as jest.Mock).mockReturnValue({ isSignedIn: false, isLoaded: true });
+  });
+
+  it('renders app name, tagline, and Get Started button when not signed in and Clerk is loaded', () => {
+    render(<WelcomeScreen />);
+
+    expect(screen.getByText('Sophros')).toBeTruthy();
+    expect(screen.getByText('Your personal health companion')).toBeTruthy();
+    expect(screen.getByText('Get Started')).toBeTruthy();
+  });
+
+  it('navigates to sign-in when Get Started is pressed', () => {
+    render(<WelcomeScreen />);
+
+    fireEvent.press(screen.getByText('Get Started'));
+
+    expect(router.push).toHaveBeenCalledWith('/(auth)/sign-in');
+  });
+
+  it('redirects to auth if already signed in', () => {
+    (useAuth as jest.Mock).mockReturnValue({ isSignedIn: true, isLoaded: true });
+
+    const { UNSAFE_getByType } = render(<WelcomeScreen />);
+
+    expect(UNSAFE_getByType(Redirect)).toBeTruthy();
+  });
+
+  it('returns null when Clerk is not loaded', () => {
+    (useAuth as jest.Mock).mockReturnValue({ isLoaded: false });
+
+    const { toJSON } = render(<WelcomeScreen />);
+
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/frontend/__tests__/screens/welcome.test.tsx
+++ b/frontend/__tests__/screens/welcome.test.tsx
@@ -41,7 +41,7 @@ describe('WelcomeScreen', () => {
     expect(router.replace).toHaveBeenCalledWith('/(auth)/sign-in');
   });
 
-  it('redirects to auth if already signed in', () => {
+  it('redirects to main app if already signed in', () => {
     (useAuth as jest.Mock).mockReturnValue({ isSignedIn: true, isLoaded: true });
 
     const { UNSAFE_getByType } = render(<WelcomeScreen />);

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,10 +1,10 @@
+import type { Day } from '@/api/types.gen';
 import { MacroNutrients } from '@/components/MacroNutrients';
 import { Colors, Layout, Shadows } from '@/constants/theme';
 import { useSavedWeekPlanQuery } from '@/lib/queries/mealPlan';
 import { useUserQuery, useUserTargetsQuery } from '@/lib/queries/user';
 import { calculateHealthScore } from '@/utils/healthScore';
 import { mapDailyPlanToScheduleItems } from '@/utils/mealPlanMapper';
-import type { Day } from '@/api/types.gen';
 import { useUser as useClerkUser } from '@clerk/expo';
 import { useRouter } from 'expo-router';
 import { ChevronRight, Utensils } from 'lucide-react-native';
@@ -29,7 +29,7 @@ const JS_DAY_TO_API_DAY: Record<number, Day> = {
   6: 'Saturday',
 };
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
   const router = useRouter();
 
   const { user: clerkUser } = useClerkUser();

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -29,7 +29,7 @@ const JS_DAY_TO_API_DAY: Record<number, Day> = {
   6: 'Saturday',
 };
 
-export default async function DashboardPage() {
+export default function DashboardPage() {
   const router = useRouter();
 
   const { user: clerkUser } = useClerkUser();

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -40,6 +40,7 @@ export default function RootLayout() {
               <Stack>
                 <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
                 <Stack.Screen name="index" options={{ headerShown: false }} />
+                <Stack.Screen name="welcome" options={{ headerShown: false }} />
                 <Stack.Screen name="onboarding" options={{ headerShown: false }} />
                 <Stack.Screen name="(auth)" options={{ headerShown: false }} />
                 <Stack.Screen name="week-planning" options={{ headerShown: false }} />

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,6 +1,5 @@
 import { Redirect } from 'expo-router';
 
 export default function Index() {
-  // Auth will handle redirecting to the correct screen
-  return <Redirect href={'/(auth)/sign-in'} />;
+  return <Redirect href="/welcome" />;
 }

--- a/frontend/app/welcome.tsx
+++ b/frontend/app/welcome.tsx
@@ -1,0 +1,87 @@
+import { useAuth } from '@clerk/expo';
+import { Redirect, router } from 'expo-router';
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { Colors } from '@/constants/theme';
+
+export default function WelcomeScreen() {
+  const { isSignedIn } = useAuth();
+
+  if (isSignedIn) {
+    return <Redirect href="/(auth)/sign-in" />;
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <Image
+            source={require('@/assets/images/splash-icon.png')}
+            style={styles.logo}
+            resizeMode="contain"
+          />
+          <Text style={styles.title}>Sophros</Text>
+          <Text style={styles.tagline}>Your personal health companion</Text>
+        </View>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => router.push('/(auth)/sign-in')}
+            activeOpacity={0.8}
+          >
+            <Text style={styles.buttonText}>Get Started</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.light.background,
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingBottom: 40,
+    justifyContent: 'space-between',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  logo: {
+    width: 120,
+    height: 120,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: 8,
+  },
+  tagline: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+    textAlign: 'center',
+  },
+  buttonContainer: {
+    gap: 12,
+  },
+  button: {
+    backgroundColor: Colors.light.primary,
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.surface,
+  },
+});

--- a/frontend/app/welcome.tsx
+++ b/frontend/app/welcome.tsx
@@ -13,7 +13,7 @@ export default function WelcomeScreen() {
   }
 
   if (isSignedIn) {
-    return <Redirect href="/(auth)/sign-in" />;
+    return <Redirect href="/(tabs)" />;
   }
 
   return (

--- a/frontend/app/welcome.tsx
+++ b/frontend/app/welcome.tsx
@@ -31,7 +31,7 @@ export default function WelcomeScreen() {
         <View style={styles.buttonContainer}>
           <TouchableOpacity
             style={styles.button}
-            onPress={() => router.push('/(auth)/sign-in')}
+            onPress={() => router.replace('/(auth)/sign-in')}
             activeOpacity={0.8}
           >
             <Text style={styles.buttonText}>Get Started</Text>

--- a/frontend/app/welcome.tsx
+++ b/frontend/app/welcome.tsx
@@ -6,7 +6,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Colors } from '@/constants/theme';
 
 export default function WelcomeScreen() {
-  const { isSignedIn } = useAuth();
+  const { isSignedIn, isLoaded } = useAuth();
+
+  if (!isLoaded) {
+    return null;
+  }
 
   if (isSignedIn) {
     return <Redirect href="/(auth)/sign-in" />;
@@ -70,9 +74,7 @@ const styles = StyleSheet.create({
     color: Colors.light.textMuted,
     textAlign: 'center',
   },
-  buttonContainer: {
-    gap: 12,
-  },
+  buttonContainer: {},
   button: {
     backgroundColor: Colors.light.primary,
     borderRadius: 12,


### PR DESCRIPTION
## Summary

Adds a branded welcome landing screen shown to unauthenticated users before they hit the Clerk sign-in flow. Until now the app booted straight into sign-in, which felt abrupt and gave us nowhere to put the logo, app name, and tagline. The welcome screen shows those plus a Get Started button that routes into sign-in. Signed-in users bypass the screen, with an isLoaded guard so there is no flash of welcome content during Clerk initialization.

## Issues

Closes #210
