### PR TITLE
ci: don't autogenerate sbom on PR

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,18 +1,6 @@
 name: Generate SBOM
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - ".github/workflows/sbom.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - ".github/workflows/sbom.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Stops sbom from generating on every commit on every PR

Allows sbom generation on manual trigger
