### PR TITLE
feat: edit schedule items + leftover cascade on #231's refactor

### DIFF
--- a/backend/app/api/endpoints/schedules.py
+++ b/backend/app/api/endpoints/schedules.py
@@ -2,7 +2,7 @@
 from datetime import datetime, time, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -178,5 +178,9 @@ async def delete_schedule_item(
             status_code=status.HTTP_404_NOT_FOUND, detail="Schedule item not found"
         )
 
+    # Cascade: remove any downstream leftovers that point at this item
+    await db.execute(
+        delete(ScheduleItem).where(ScheduleItem.source_schedule_item_id == item_id)
+    )
     await db.delete(item)
     await db.commit()

--- a/backend/app/api/endpoints/schedules.py
+++ b/backend/app/api/endpoints/schedules.py
@@ -2,7 +2,7 @@
 from datetime import datetime, time, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -155,6 +155,12 @@ async def swap_schedule_item_meal(
         )
 
     item.meal_id = body.meal_id
+    # Cascade new meal_id to all downstream leftovers
+    await db.execute(
+        update(ScheduleItem)
+        .where(ScheduleItem.source_schedule_item_id == item_id)
+        .values(meal_id=body.meal_id)
+    )
     db.add(item)
     await db.commit()
     db.expire(item)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -13,7 +13,15 @@ def get_engine():
     """Get or create the async engine (lazy initialization)."""
     global _engine
     if _engine is None:
-        _engine = create_async_engine(settings.DATABASE_URL, echo=True, future=True)
+        _engine = create_async_engine(
+            settings.DATABASE_URL,
+            echo=True,
+            future=True,
+            # Neon pgbouncer-style pooler invalidates prepared statements across
+            # reconnects; disable asyncpg's statement cache to avoid
+            # InvalidCachedStatementError after any schema change.
+            connect_args={"statement_cache_size": 0},
+        )
     return _engine
 
 

--- a/backend/tests/test_schedules.py
+++ b/backend/tests/test_schedules.py
@@ -273,3 +273,61 @@ async def test_delete_primary_cascades_to_leftovers(client, db, mock_user):
 
     remaining = await db.get(ScheduleItem, leftover_id)
     assert remaining is None, "leftover should have been deleted along with its source"
+
+
+@pytest.mark.asyncio
+async def test_swap_primary_cascades_to_leftovers(
+    client, db, mock_user
+):
+    meal_a = Meal(
+        recipe_id="a",
+        title="Chili",
+        calories=500, protein=30, carbohydrates=40, fat=20,
+        ingredients=[], tags=[],
+    )
+    meal_b = Meal(
+        recipe_id="b",
+        title="Soup",
+        calories=300, protein=20, carbohydrates=30, fat=10,
+        ingredients=[], tags=[],
+    )
+    db.add_all([meal_a, meal_b])
+    await db.flush()
+
+    source = ScheduleItem(
+        user_id=mock_user.id,
+        date=datetime(2026, 4, 20, 18, 0),
+        activity_type=ActivityType.MEAL,
+        duration_minutes=30,
+        meal_id=meal_a.id,
+    )
+    db.add(source)
+    await db.flush()
+
+    # Register meal_b as an alternative for the source
+    db.add(ScheduleItemAlternative(schedule_item_id=source.id, meal_id=meal_b.id))
+
+    leftover = ScheduleItem(
+        user_id=mock_user.id,
+        date=datetime(2026, 4, 21, 12, 0),
+        activity_type=ActivityType.MEAL,
+        duration_minutes=10,
+        meal_id=meal_a.id,
+        source_schedule_item_id=source.id,
+    )
+    db.add(leftover)
+    await db.commit()
+
+    leftover_id = leftover.id
+    source_id = source.id
+
+    resp = await client.post(
+        f"/api/v1/schedules/{source_id}/swap", json={"meal_id": meal_b.id}
+    )
+    assert resp.status_code == 200
+
+    await db.refresh(source)
+    refreshed = await db.get(ScheduleItem, leftover_id)
+    assert source.meal_id == meal_b.id
+    assert refreshed is not None
+    assert refreshed.meal_id == meal_b.id, "leftover's meal_id should follow the source"

--- a/backend/tests/test_schedules.py
+++ b/backend/tests/test_schedules.py
@@ -276,20 +276,26 @@ async def test_delete_primary_cascades_to_leftovers(client, db, mock_user):
 
 
 @pytest.mark.asyncio
-async def test_swap_primary_cascades_to_leftovers(
-    client, db, mock_user
-):
+async def test_swap_primary_cascades_to_leftovers(client, db, mock_user):
     meal_a = Meal(
         recipe_id="a",
         title="Chili",
-        calories=500, protein=30, carbohydrates=40, fat=20,
-        ingredients=[], tags=[],
+        calories=500,
+        protein=30,
+        carbohydrates=40,
+        fat=20,
+        ingredients=[],
+        tags=[],
     )
     meal_b = Meal(
         recipe_id="b",
         title="Soup",
-        calories=300, protein=20, carbohydrates=30, fat=10,
-        ingredients=[], tags=[],
+        calories=300,
+        protein=20,
+        carbohydrates=30,
+        fat=10,
+        ingredients=[],
+        tags=[],
     )
     db.add_all([meal_a, meal_b])
     await db.flush()

--- a/backend/tests/test_schedules.py
+++ b/backend/tests/test_schedules.py
@@ -1,4 +1,4 @@
-from datetime import datetime as dt_type
+from datetime import datetime
 
 import pytest
 from httpx import AsyncClient
@@ -127,7 +127,7 @@ async def _create_meal(db, **kwargs) -> Meal:
 async def _create_meal_schedule_item(
     db, user_id: str, day_offset: int, meal: Meal
 ) -> ScheduleItem:
-    monday = dt_type(2025, 6, 2)
+    monday = datetime(2025, 6, 2)
     item_dt = monday.replace(day=monday.day + day_offset, hour=8)
     item = ScheduleItem(
         user_id=user_id,
@@ -227,3 +227,49 @@ async def test_swap_meal_invalid_meal_id(client: AsyncClient, db, mock_user):
 async def test_swap_meal_not_found(client: AsyncClient):
     response = await client.post(f"{BASE}/99999/swap", json={"meal_id": 1})
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_primary_cascades_to_leftovers(client, db, mock_user):
+    meal = Meal(
+        recipe_id="r1",
+        title="Chili",
+        calories=500,
+        protein=30,
+        carbohydrates=40,
+        fat=20,
+        ingredients=[],
+        tags=[],
+    )
+    db.add(meal)
+    await db.flush()
+
+    source = ScheduleItem(
+        user_id=mock_user.id,
+        date=datetime(2026, 4, 20, 18, 0),
+        activity_type=ActivityType.MEAL,
+        duration_minutes=30,
+        meal_id=meal.id,
+    )
+    db.add(source)
+    await db.flush()
+
+    leftover = ScheduleItem(
+        user_id=mock_user.id,
+        date=datetime(2026, 4, 21, 12, 0),
+        activity_type=ActivityType.MEAL,
+        duration_minutes=10,
+        meal_id=meal.id,
+        source_schedule_item_id=source.id,
+    )
+    db.add(leftover)
+    await db.commit()
+
+    leftover_id = leftover.id
+    source_id = source.id
+
+    resp = await client.delete(f"/api/v1/schedules/{source_id}")
+    assert resp.status_code == 204
+
+    remaining = await db.get(ScheduleItem, leftover_id)
+    assert remaining is None, "leftover should have been deleted along with its source"

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -105,6 +105,38 @@ describe('DashboardPage (Home)', () => {
     expect(screen.getByText(/No meals planned yet/i)).toBeTruthy();
   });
 
+  it('shows "All done for today" when today had meals but all have already passed', () => {
+    // `useNow` is globally mocked to 2026-01-15T10:00 local (jest.setup.ts).
+    // Place the meal at 08:00 that day so it's past-but-same-day.
+    const pastMeal = new Date(2026, 0, 15, 8, 0, 0);
+    (useWeekScheduleQuery as jest.Mock).mockReturnValue({
+      data: [
+        {
+          id: 1,
+          user_id: 'u',
+          date: pastMeal.toISOString(),
+          activity_type: 'meal',
+          is_completed: false,
+          duration_minutes: 15,
+          meal: {
+            id: 10,
+            title: 'Breakfast',
+            calories: 300,
+            protein: 20,
+            carbohydrates: 30,
+            fat: 10,
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProviders(<DashboardPage />);
+    expect(screen.getByText(/All done for today/i)).toBeTruthy();
+    expect(screen.queryByText(/No meals planned yet/i)).toBeNull();
+  });
+
   it("shows the user's first name in the greeting when Clerk user has firstName", async () => {
     // Override the global Clerk mock for this test only
     (useUser as jest.Mock).mockReturnValueOnce({

--- a/frontend/__tests__/screens/home.test.tsx
+++ b/frontend/__tests__/screens/home.test.tsx
@@ -48,7 +48,11 @@ jest.mock('@/lib/queries/user', () => ({
 }));
 
 // Note: the home screen imports useUser from @clerk/expo (as useClerkUser alias),
-// not from @/contexts/UserContext — the global mock in jest.setup.ts covers this.
+// but also reads from our UserContext for health-score calculation; stub the
+// context module so the test doesn't need a real UserProvider wrapper.
+jest.mock('@/contexts/UserContext', () => ({
+  useUser: jest.fn(() => ({ user: null, isOnboarded: false, loading: false })),
+}));
 
 jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: ({ children }: { children: React.ReactNode }) => children,

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -123,7 +123,13 @@ export default function DashboardPage() {
   // Sum nutrients of completed meal items for today
   const consumedTotals = useMemo(() => {
     return todayMealItems
-      .filter((item) => item.is_completed && item.meal)
+      .filter((item) => {
+        if (!item.meal) return false;
+        if (item.is_completed) return true;
+        const itemMins =
+          new Date(item.date).getHours() * 60 + new Date(item.date).getMinutes();
+        return itemMins <= nowMins;
+      })
       .reduce(
         (acc, item) => ({
           calories: acc.calories + (item.meal?.calories ?? 0),
@@ -133,7 +139,7 @@ export default function DashboardPage() {
         }),
         { calories: 0, protein: 0, carbs: 0, fat: 0 }
       );
-  }, [todayMealItems]);
+  }, [todayMealItems, nowMins]);
 
   // Derive macro data — when items have been confirmed, show consumed vs planned
   const macroData = useMemo(() => {

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import { MacroNutrients } from '@/components/MacroNutrients';
+import { MealDetailModal } from '@/components/MealDetailModal';
 import { Colors, Layout, Shadows } from '@/constants/theme';
 import { useUser } from '@/contexts/UserContext';
 import { useNow } from '@/hooks/useNow';
@@ -8,10 +9,11 @@ import { mondayOf } from '@/utils/date';
 import { calculateHealthScore } from '@/utils/healthScore';
 import { useActiveEnergyToday, useStepsToday, useSleepLastNight } from '@/lib/healthkit';
 import type { HealthKitInputs } from '@/lib/healthkit';
+import type { ScheduleItemRead } from '@/api/types.gen';
 import { useUser as useClerkUser } from '@clerk/expo';
 import { useRouter } from 'expo-router';
 import { ChevronRight, Utensils } from 'lucide-react-native';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   ScrollView,
@@ -108,6 +110,7 @@ export default function DashboardPage() {
       })
       .slice(0, 3)
       .map((item) => ({
+        item,
         time: formatDisplayTime(item.date),
         title: item.meal?.title ?? 'Meal',
         subtitle: item.meal ? `${item.meal.calories} cal` : '',
@@ -115,6 +118,14 @@ export default function DashboardPage() {
         color: Colors.light.secondary,
       }));
   }, [todayMealItems, nowMins]);
+
+  const [selectedItem, setSelectedItem] = useState<ScheduleItemRead | null>(null);
+  const [detailModalVisible, setDetailModalVisible] = useState(false);
+
+  const handleUpcomingPress = useCallback((item: ScheduleItemRead) => {
+    setSelectedItem(item);
+    setDetailModalVisible(true);
+  }, []);
 
   // Sum nutrients of completed meal items for today
   const consumedTotals = useMemo(() => {
@@ -290,25 +301,26 @@ export default function DashboardPage() {
 
             {upcomingItems.length > 0 ? (
               <View style={styles.listContainer}>
-                {upcomingItems.map((item, i) => (
+                {upcomingItems.map((entry, i) => (
                   <TouchableOpacity
-                    key={i}
+                    key={entry.item.id}
                     style={[styles.listItem, i === 0 && styles.activeListItem]}
+                    onPress={() => handleUpcomingPress(entry.item)}
                   >
-                    <View style={[styles.iconBox, { backgroundColor: `${item.color}15` }]}>
-                      <item.icon size={24} color={item.color} />
+                    <View style={[styles.iconBox, { backgroundColor: `${entry.color}15` }]}>
+                      <entry.icon size={24} color={entry.color} />
                     </View>
                     <View style={styles.itemContent}>
                       <Text style={styles.itemTitle} numberOfLines={1}>
-                        {item.title}
+                        {entry.title}
                       </Text>
                       <Text style={styles.itemSubtitle} numberOfLines={1}>
-                        {item.subtitle}
+                        {entry.subtitle}
                       </Text>
                     </View>
                     <View style={styles.timeBox}>
                       <View style={styles.timeBadge}>
-                        <Text style={styles.timeText}>{item.time}</Text>
+                        <Text style={styles.timeText}>{entry.time}</Text>
                       </View>
                     </View>
                   </TouchableOpacity>
@@ -317,7 +329,9 @@ export default function DashboardPage() {
             ) : (
               <View style={styles.emptyUpcoming}>
                 <Text style={styles.emptyText}>
-                  No meals planned yet. Head to the Schedule tab to plan your week!
+                  {todayMealItems.length > 0
+                    ? 'All done for today — check back tomorrow!'
+                    : 'No meals planned yet. Head to the Schedule tab to plan your week!'}
                 </Text>
               </View>
             )}
@@ -334,6 +348,22 @@ export default function DashboardPage() {
           </View>
         </ScrollView>
       )}
+
+      <MealDetailModal
+        visible={detailModalVisible}
+        onClose={() => setDetailModalVisible(false)}
+        readOnly
+        meal={
+          selectedItem
+            ? {
+                time: formatDisplayTime(selectedItem.date),
+                title: selectedItem.meal?.title ?? 'Meal',
+                type: selectedItem.activity_type,
+                meal: selectedItem.meal,
+              }
+            : null
+        }
+      />
     </SafeAreaView>
   );
 }

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -126,8 +126,7 @@ export default function DashboardPage() {
       .filter((item) => {
         if (!item.meal) return false;
         if (item.is_completed) return true;
-        const itemMins =
-          new Date(item.date).getHours() * 60 + new Date(item.date).getMinutes();
+        const itemMins = new Date(item.date).getHours() * 60 + new Date(item.date).getMinutes();
         return itemMins <= nowMins;
       })
       .reduce(

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,9 +1,11 @@
 import { MacroNutrients } from '@/components/MacroNutrients';
 import { Colors, Layout, Shadows } from '@/constants/theme';
+import { useUser } from '@/contexts/UserContext';
 import { useNow } from '@/hooks/useNow';
 import { useWeekScheduleQuery } from '@/lib/queries/schedule';
 import { useUserQuery, useUserTargetsQuery } from '@/lib/queries/user';
-import { calculateHealthScore, type DailyNutritionTotals } from '@/utils/healthScore';
+import { mondayOf } from '@/utils/date';
+import { calculateHealthScore } from '@/utils/healthScore';
 import { useActiveEnergyToday, useStepsToday, useSleepLastNight } from '@/lib/healthkit';
 import type { HealthKitInputs } from '@/lib/healthkit';
 import { useUser as useClerkUser } from '@clerk/expo';
@@ -43,17 +45,12 @@ export default function DashboardPage() {
   const currentMinute = now.getMinutes();
 
   // Compute this week's Monday to fetch the saved plan
-  const weekStartStr = useMemo(() => {
-    const d = new Date(now);
-    const dow = d.getDay();
-    const diff = dow === 0 ? -6 : 1 - dow;
-    d.setDate(d.getDate() + diff);
-    return d.toISOString().split('T')[0];
-  }, [now.toDateString()]); // eslint-disable-line react-hooks/exhaustive-deps
+  const weekStartStr = useMemo(() => mondayOf(now), [now.toDateString()]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { data: scheduleItems = [], isLoading: isLoadingPlan } = useWeekScheduleQuery(weekStartStr);
   const { data: targets, isLoading: isLoadingTargets } = useUserTargetsQuery();
-  const { data: user, isLoading: isLoadingUser } = useUserQuery();
+  const { isLoading: isLoadingUser } = useUserQuery();
+  const { user: backendUser } = useUser();
 
   const { data: hkActive } = useActiveEnergyToday();
   const { data: hkSteps } = useStepsToday();
@@ -84,23 +81,22 @@ export default function DashboardPage() {
     });
   }, [scheduleItems, now.toDateString()]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Derive today's nutrition totals from schedule items for health score
-  const todayPlan = useMemo((): DailyNutritionTotals | undefined => {
-    const mealsWithData = todayMealItems.filter((i) => i.meal != null);
-    if (mealsWithData.length === 0) return undefined;
-    return {
-      total_calories: mealsWithData.reduce((s, i) => s + (i.meal?.calories ?? 0), 0),
-      total_protein: mealsWithData.reduce((s, i) => s + (i.meal?.protein ?? 0), 0),
-      total_carbs: mealsWithData.reduce((s, i) => s + (i.meal?.carbohydrates ?? 0), 0),
-      total_fat: mealsWithData.reduce((s, i) => s + (i.meal?.fat ?? 0), 0),
-    };
-  }, [todayMealItems]);
-
-  // Compute health score
-  const healthScore = useMemo(
-    () => calculateHealthScore(todayPlan, targets, user, !!todayPlan, hkInputs),
-    [todayPlan, targets, user, hkInputs]
-  );
+  // Compute health score — uses the same calculator as the detail page so the
+  // two screens never disagree.
+  const healthScore = useMemo(() => {
+    const completed = todayMealItems.filter((i) => i.is_completed && i.meal);
+    const totals = completed.reduce(
+      (acc, i) => ({
+        total_calories: acc.total_calories + (i.meal?.calories ?? 0),
+        total_protein: acc.total_protein + (i.meal?.protein ?? 0),
+        total_carbs: acc.total_carbs + (i.meal?.carbohydrates ?? 0),
+        total_fat: acc.total_fat + (i.meal?.fat ?? 0),
+      }),
+      { total_calories: 0, total_protein: 0, total_carbs: 0, total_fat: 0 }
+    );
+    const hasPlan = todayMealItems.length > 0;
+    return calculateHealthScore(totals, targets, backendUser, hasPlan, hkInputs);
+  }, [todayMealItems, targets, backendUser, hkInputs]);
 
   // Derive upcoming meals (items whose time is still in the future and not completed)
   const upcomingItems = useMemo(() => {

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -1,15 +1,15 @@
+import type { ScheduleItemRead } from '@/api/types.gen';
 import { MacroNutrients } from '@/components/MacroNutrients';
 import { MealDetailModal } from '@/components/MealDetailModal';
 import { Colors, Layout, Shadows } from '@/constants/theme';
 import { useUser } from '@/contexts/UserContext';
 import { useNow } from '@/hooks/useNow';
+import type { HealthKitInputs } from '@/lib/healthkit';
+import { useActiveEnergyToday, useSleepLastNight, useStepsToday } from '@/lib/healthkit';
 import { useWeekScheduleQuery } from '@/lib/queries/schedule';
 import { useUserQuery, useUserTargetsQuery } from '@/lib/queries/user';
 import { mondayOf } from '@/utils/date';
 import { calculateHealthScore } from '@/utils/healthScore';
-import { useActiveEnergyToday, useStepsToday, useSleepLastNight } from '@/lib/healthkit';
-import type { HealthKitInputs } from '@/lib/healthkit';
-import type { ScheduleItemRead } from '@/api/types.gen';
 import { useUser as useClerkUser } from '@clerk/expo';
 import { useRouter } from 'expo-router';
 import { ChevronRight, Utensils } from 'lucide-react-native';
@@ -130,12 +130,7 @@ export default function DashboardPage() {
   // Sum nutrients of completed meal items for today
   const consumedTotals = useMemo(() => {
     return todayMealItems
-      .filter((item) => {
-        if (!item.meal) return false;
-        if (item.is_completed) return true;
-        const itemMins = new Date(item.date).getHours() * 60 + new Date(item.date).getMinutes();
-        return itemMins <= nowMins;
-      })
+      .filter((item) => item.meal && item.is_completed)
       .reduce(
         (acc, item) => ({
           calories: acc.calories + (item.meal?.calories ?? 0),

--- a/frontend/app/(tabs)/progress.tsx
+++ b/frontend/app/(tabs)/progress.tsx
@@ -2,18 +2,14 @@ import { Colors, Layout, Shadows } from '@/constants/theme';
 import { useAchievements } from '@/hooks/useAchievements';
 import { useStreak } from '@/hooks/useStreak';
 import { useWeekScheduleQuery } from '@/lib/queries/schedule';
+import { mondayOf } from '@/utils/date';
 import { Award, ChevronDown, ChevronUp } from 'lucide-react-native';
 import React, { useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ProgressPage() {
-  const weekStartStr = useMemo(() => {
-    const d = new Date();
-    const dow = d.getDay();
-    d.setDate(d.getDate() - (dow === 0 ? 6 : dow - 1));
-    return d.toISOString().split('T')[0];
-  }, []);
+  const weekStartStr = useMemo(() => mondayOf(new Date()), []);
 
   const { data: scheduleItems = [] } = useWeekScheduleQuery(weekStartStr);
   const streak = useStreak();

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -169,15 +169,20 @@ export default function SchedulePage() {
   }, []);
 
   const handleMealModify = useCallback(
-    (meal: { time: string; title?: string; subtitle?: string; type: string }) => {
+    (mealData: { time: string; title?: string; subtitle?: string; type: string }) => {
       if (!selectedItem) return;
+      const m = selectedItem.meal;
       setEditModalItem({
         id: String(selectedItem.id),
-        time: meal.time,
-        title: meal.title || 'Meal',
-        subtitle: meal.subtitle,
+        time: mealData.time,
+        title: mealData.title || 'Meal',
+        subtitle: mealData.subtitle,
         duration: getDurationDisplay(selectedItem.duration_minutes),
         type: 'meal',
+        calories: m?.calories,
+        protein: m?.protein,
+        carbs: m?.carbohydrates,
+        fat: m?.fat,
       });
       setEditModalMode('edit');
       setEditModalItemType('meal');

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -466,21 +466,18 @@ export default function SchedulePage() {
               const durationDisplay = getDurationDisplay(item.duration_minutes);
 
               return (
-                <SwipeableScheduleItem
-                  key={item.id || i}
-                  needsConfirmation={needsConfirmation}
-                  isCompleted={isCompleted}
-                  onConfirmDone={() => handleConfirmDone(item)}
-                  onConfirmMissed={() => handleConfirmMissed(item)}
-                >
-                  <View style={styles.timelineItem}>
-                    <View style={styles.timeColumn}>
-                      <Text style={styles.itemTime}>{displayTime}</Text>
-                      {needsConfirmation && !isCompleted && (
-                        <Text style={styles.pendingDot}>●</Text>
-                      )}
-                    </View>
+                <View key={item.id || i} style={styles.timelineItem}>
+                  <View style={styles.timeColumn}>
+                    <Text style={styles.itemTime}>{displayTime}</Text>
+                    {needsConfirmation && !isCompleted && <Text style={styles.pendingDot}>●</Text>}
+                  </View>
 
+                  <SwipeableScheduleItem
+                    needsConfirmation={needsConfirmation}
+                    isCompleted={isCompleted}
+                    onConfirmDone={() => handleConfirmDone(item)}
+                    onConfirmMissed={() => handleConfirmMissed(item)}
+                  >
                     <TouchableOpacity
                       style={[
                         styles.eventCard,
@@ -532,8 +529,8 @@ export default function SchedulePage() {
                         <Text style={styles.swipeHint}>← swipe to log · swipe to confirm →</Text>
                       )}
                     </TouchableOpacity>
-                  </View>
-                </SwipeableScheduleItem>
+                  </SwipeableScheduleItem>
+                </View>
               );
             })}
           </View>

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -1,3 +1,4 @@
+import type { ScheduleItemRead } from '@/api/types.gen';
 import { EditItemModal } from '@/components/EditItemModal';
 import { MealDetailModal } from '@/components/MealDetailModal';
 import { MissedItemModal } from '@/components/MissedItemModal';
@@ -8,8 +9,7 @@ import {
 } from '@/components/SleepWakePrompt';
 import { SwipeableScheduleItem } from '@/components/SwipeableScheduleItem';
 import { Colors } from '@/constants/theme';
-import type { ScheduleItemRead } from '@/api/types.gen';
-import type { ItemType, WeeklyScheduleItem } from '@/types/schedule';
+import { useNow } from '@/hooks/useNow';
 import {
   useCompleteScheduleItemMutation,
   useCreateScheduleItemMutation,
@@ -17,13 +17,13 @@ import {
   useUpdateScheduleItemMutation,
   useWeekScheduleQuery,
 } from '@/lib/queries/schedule';
+import type { ItemType, WeeklyScheduleItem } from '@/types/schedule';
+import { toLocalDateStr as formatDateStr } from '@/utils/date';
 import { useRouter } from 'expo-router';
 import { Calendar, ChevronLeft, ChevronRight, Dumbbell, Utensils } from 'lucide-react-native';
-import { useNow } from '@/hooks/useNow';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { toLocalDateStr as formatDateStr } from '@/utils/date';
 
 const DAY_NAMES_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -500,13 +500,7 @@ export default function SchedulePage() {
                         >
                           <Text style={styles.eventTitle} numberOfLines={1}>
                             {title}
-                            {isDone && ' ✓'}
                           </Text>
-                          {isDone && (
-                            <View style={styles.doneBadge}>
-                              <Text style={styles.doneBadgeText}>Done</Text>
-                            </View>
-                          )}
                         </View>
                         <View style={styles.durationBadge}>
                           <Text style={styles.durationText}>{durationDisplay}</Text>
@@ -519,11 +513,6 @@ export default function SchedulePage() {
                             <Text style={styles.leftoverPillText}>Leftover</Text>
                           </View>
                         </View>
-                      )}
-                      {item.meal?.tags && item.meal.tags.length > 0 && (
-                        <Text style={styles.eventSubtitle}>
-                          {item.meal.tags.slice(0, 3).join(', ')}
-                        </Text>
                       )}
                       {needsConfirmation && !isCompleted && (
                         <Text style={styles.swipeHint}>← swipe to log · swipe to confirm →</Text>

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -501,6 +501,11 @@ export default function SchedulePage() {
                               <Text style={styles.doneBadgeText}>Done</Text>
                             </View>
                           )}
+                          {item.source_schedule_item_id != null && (
+                            <View style={styles.leftoverPill}>
+                              <Text style={styles.leftoverPillText}>Leftover</Text>
+                            </View>
+                          )}
                         </View>
                         <View style={styles.durationBadge}>
                           <Text style={styles.durationText}>{durationDisplay}</Text>
@@ -841,5 +846,16 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: Colors.light.text,
+  },
+  leftoverPill: {
+    backgroundColor: Colors.light.surface,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  leftoverPillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: Colors.light.textMuted,
   },
 });

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -237,7 +237,10 @@ export default function SchedulePage() {
 
         // Rebuild date from modal's time string + the original item's day
         const originalItem = scheduleItems.find((i) => i.id === itemId);
-        if (!originalItem) return;
+        if (!originalItem) {
+          Alert.alert('Error', 'Schedule item no longer exists. Refresh and try again.');
+          return;
+        }
         const originalDate = new Date(originalItem.date);
 
         const [timePart, period] = updatedItem.time.split(' ');

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -23,6 +23,7 @@ import { useNow } from '@/hooks/useNow';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { toLocalDateStr as formatDateStr } from '@/utils/date';
 
 const DAY_NAMES_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -35,10 +36,6 @@ function getMonday(weekOffset: number): Date {
   monday.setDate(today.getDate() + diff + weekOffset * 7);
   monday.setHours(0, 0, 0, 0);
   return monday;
-}
-
-function formatDateStr(d: Date): string {
-  return d.toISOString().split('T')[0];
 }
 
 /** Derive a display time string (e.g. "7:30 AM") from an ISO date string */
@@ -211,6 +208,13 @@ export default function SchedulePage() {
 
   const handleEditSave = useCallback(
     (updatedItem: WeeklyScheduleItem) => {
+      // Build a naive ISO string from local components so it round-trips
+      // cleanly into the backend's TIMESTAMP WITHOUT TIME ZONE column.
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const toNaiveIso = (d: Date) =>
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+        `T${pad(d.getHours())}:${pad(d.getMinutes())}:00`;
+
       if (editModalMode === 'add') {
         // Compute the date for the selected day
         const dayDate = weekDates[selectedDayIndex];
@@ -230,7 +234,7 @@ export default function SchedulePage() {
 
         createMutation.mutate({
           body: {
-            date: itemDate.toISOString(),
+            date: toNaiveIso(itemDate),
             activity_type: activityType,
             duration_minutes: durationMinutes,
           },
@@ -257,12 +261,17 @@ export default function SchedulePage() {
         const newDate = new Date(originalDate);
         newDate.setHours(hours, m || 0, 0, 0);
 
-        const durationMinutes = parseInt(updatedItem.duration) || originalItem.duration_minutes;
+        // For meals, duration is read-only (comes from the recipe); keep the
+        // original value so the user can't change it accidentally via edit.
+        const isMeal = originalItem.activity_type === 'meal';
+        const durationMinutes = isMeal
+          ? originalItem.duration_minutes
+          : parseInt(updatedItem.duration) || originalItem.duration_minutes;
 
         updateMutation.mutate({
           itemId,
           body: {
-            date: newDate.toISOString(),
+            date: toNaiveIso(newDate),
             duration_minutes: durationMinutes,
           },
           weekStartDate: weekStartStr,
@@ -501,17 +510,19 @@ export default function SchedulePage() {
                               <Text style={styles.doneBadgeText}>Done</Text>
                             </View>
                           )}
-                          {item.source_schedule_item_id != null && (
-                            <View style={styles.leftoverPill}>
-                              <Text style={styles.leftoverPillText}>Leftover</Text>
-                            </View>
-                          )}
                         </View>
                         <View style={styles.durationBadge}>
                           <Text style={styles.durationText}>{durationDisplay}</Text>
                         </View>
                       </View>
 
+                      {item.source_schedule_item_id != null && (
+                        <View style={styles.leftoverPillRow}>
+                          <View style={styles.leftoverPill}>
+                            <Text style={styles.leftoverPillText}>Leftover</Text>
+                          </View>
+                        </View>
+                      )}
                       {item.meal?.tags && item.meal.tags.length > 0 && (
                         <Text style={styles.eventSubtitle}>
                           {item.meal.tags.slice(0, 3).join(', ')}
@@ -847,11 +858,16 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: Colors.light.text,
   },
+  leftoverPillRow: {
+    flexDirection: 'row',
+    marginTop: 4,
+  },
   leftoverPill: {
-    backgroundColor: Colors.light.surface,
+    backgroundColor: Colors.light.background,
     paddingHorizontal: 8,
     paddingVertical: 2,
     borderRadius: 8,
+    alignSelf: 'flex-start',
   },
   leftoverPillText: {
     fontSize: 11,

--- a/frontend/app/(tabs)/schedule.tsx
+++ b/frontend/app/(tabs)/schedule.tsx
@@ -233,14 +233,32 @@ export default function SchedulePage() {
         });
       } else if (editModalItem) {
         const itemId = parseInt(editModalItem.id);
-        if (!isNaN(itemId)) {
-          const durationMinutes = parseInt(updatedItem.duration) || 30;
-          updateMutation.mutate({
-            itemId,
-            body: { duration_minutes: durationMinutes },
-            weekStartDate: weekStartStr,
-          });
-        }
+        if (isNaN(itemId)) return;
+
+        // Rebuild date from modal's time string + the original item's day
+        const originalItem = scheduleItems.find((i) => i.id === itemId);
+        if (!originalItem) return;
+        const originalDate = new Date(originalItem.date);
+
+        const [timePart, period] = updatedItem.time.split(' ');
+        const [h, m] = timePart.split(':').map(Number);
+        let hours = h;
+        if (period === 'PM' && h !== 12) hours += 12;
+        if (period === 'AM' && h === 12) hours = 0;
+
+        const newDate = new Date(originalDate);
+        newDate.setHours(hours, m || 0, 0, 0);
+
+        const durationMinutes = parseInt(updatedItem.duration) || originalItem.duration_minutes;
+
+        updateMutation.mutate({
+          itemId,
+          body: {
+            date: newDate.toISOString(),
+            duration_minutes: durationMinutes,
+          },
+          weekStartDate: weekStartStr,
+        });
       }
     },
     [
@@ -251,6 +269,7 @@ export default function SchedulePage() {
       selectedDayIndex,
       weekDates,
       weekStartStr,
+      scheduleItems,
     ]
   );
 

--- a/frontend/app/week-planning.tsx
+++ b/frontend/app/week-planning.tsx
@@ -10,7 +10,7 @@ import {
   useWeekScheduleQuery,
 } from '@/lib/queries/schedule';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { ArrowLeft, RefreshCw, Sparkles } from 'lucide-react-native';
+import { ArrowLeft, RefreshCw } from 'lucide-react-native';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -22,14 +22,16 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { toLocalDateStr } from '@/utils/date';
 
 const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+const DAY_NAMES_SHORT = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 function getNextMonday(): string {
   const today = new Date();
   const d = new Date(today);
   d.setDate(today.getDate() + ((8 - today.getDay()) % 7 || 7));
-  return d.toISOString().split('T')[0];
+  return toLocalDateStr(d);
 }
 
 function formatDisplayTime(isoDatetime: string): string {
@@ -56,7 +58,7 @@ export default function WeekPlanningScreen() {
   const [swapItem, setSwapItem] = useState<ScheduleItemRead | null>(null);
   const [leftoverSourceTitle, setLeftoverSourceTitle] = useState<string | null>(null);
 
-  const { backendUser, loading: profileLoading } = useUserProfile();
+  const { loading: profileLoading } = useUserProfile();
   const { data: scheduleItems = [], isLoading } = useWeekScheduleQuery(weekStart);
   const generateMutation = useGenerateWeekPlanMutation();
   const swapMutation = useSwapMealMutation();
@@ -67,10 +69,11 @@ export default function WeekPlanningScreen() {
     [scheduleItems]
   );
 
-  // Auto-generate if no meal items exist for this week
+  // Auto-generate if no meal items exist for this week.
+  // Profile completeness is enforced in onboarding, so we don't gate on it here
+  // — a transient null backendUser (e.g. API hiccup) shouldn't block generation.
   useEffect(() => {
     if (profileLoading || isLoading) return;
-    if (!backendUser?.target_weight || !backendUser?.target_date) return;
     if (mealItems.length > 0) return;
     if (generateMutation.isPending || generateMutation.isError) return;
 
@@ -147,26 +150,6 @@ export default function WeekPlanningScreen() {
     );
   }
 
-  if (!backendUser?.target_weight || !backendUser?.target_date) {
-    return (
-      <SafeAreaView style={styles.container} edges={['top']}>
-        <View style={styles.center}>
-          <Sparkles size={48} color={Colors.light.secondary} style={{ marginBottom: 16 }} />
-          <Text style={styles.heading}>Complete Your Profile</Text>
-          <Text style={styles.subtext}>
-            Set your target weight and goal date to generate a personalized meal plan.
-          </Text>
-          <TouchableOpacity
-            style={styles.primaryButton}
-            onPress={() => router.push('/profile/edit')}
-          >
-            <Text style={styles.primaryButtonText}>Go to Profile Settings</Text>
-          </TouchableOpacity>
-        </View>
-      </SafeAreaView>
-    );
-  }
-
   const isGenerating = generateMutation.isPending || (isLoading && mealItems.length === 0);
 
   if (isGenerating) {
@@ -191,46 +174,44 @@ export default function WeekPlanningScreen() {
           <ArrowLeft size={24} color={Colors.light.text} />
         </TouchableOpacity>
         <Text style={styles.headerTitle}>Week Planning</Text>
-        <TouchableOpacity
-          onPress={handleRegenerate}
-          style={styles.iconButton}
-          disabled={generateMutation.isPending}
-        >
-          {generateMutation.isPending ? (
-            <ActivityIndicator size="small" color={Colors.light.primary} />
-          ) : (
-            <RefreshCw size={20} color={Colors.light.primary} />
-          )}
-        </TouchableOpacity>
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={handleRegenerate}
+            style={styles.iconButton}
+            disabled={generateMutation.isPending}
+          >
+            {generateMutation.isPending ? (
+              <ActivityIndicator size="small" color={Colors.light.primary} />
+            ) : (
+              <RefreshCw size={20} color={Colors.light.primary} />
+            )}
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => router.back()} style={styles.doneButton}>
+            <Text style={styles.doneButtonText}>Done</Text>
+          </TouchableOpacity>
+        </View>
       </View>
 
-      {/* Day Selector */}
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        style={styles.daySelector}
-        contentContainerStyle={styles.daySelectorContent}
-      >
-        {DAY_NAMES.map((name, i) => {
+      {/* Day Selector — matches schedule tab's compact cards */}
+      <View style={styles.daySelector}>
+        {DAY_NAMES_SHORT.map((short, i) => {
           const d = new Date(weekStart + 'T00:00:00');
           d.setDate(d.getDate() + i);
-          const label = `${d.toLocaleDateString('en-US', { month: 'short' })} ${d.getDate()}`;
+          const isSelected = selectedDayIndex === i;
           return (
             <TouchableOpacity
-              key={name}
-              style={[styles.dayCard, selectedDayIndex === i && styles.activeDayCard]}
+              key={i}
+              style={[styles.dayCard, isSelected && styles.activeDayCard]}
               onPress={() => setSelectedDayIndex(i)}
             >
-              <Text style={[styles.dayName, selectedDayIndex === i && styles.activeDayName]}>
-                {name.slice(0, 3)}
-              </Text>
-              <Text style={[styles.dayDate, selectedDayIndex === i && styles.activeDayDate]}>
-                {label}
+              <Text style={[styles.dayText, isSelected && styles.activeDayText]}>{short}</Text>
+              <Text style={[styles.dateText, isSelected && styles.activeDateText]}>
+                {d.getDate()}
               </Text>
             </TouchableOpacity>
           );
         })}
-      </ScrollView>
+      </View>
 
       {/* Schedule Items */}
       <ScrollView contentContainerStyle={styles.scrollContent}>
@@ -335,22 +316,43 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  daySelector: { maxHeight: 90, borderBottomWidth: 1, borderBottomColor: '#E5E7EB' },
-  daySelectorContent: { paddingHorizontal: 16, paddingVertical: 16, gap: 12 },
+  headerActions: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  doneButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 12,
+    backgroundColor: Colors.light.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  doneButtonText: { color: '#FFFFFF', fontSize: 14, fontWeight: '600' },
+  daySelector: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
   dayCard: {
-    minWidth: 80,
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderRadius: Layout.cardRadius,
+    minWidth: 44,
+    height: 68,
+    borderRadius: 16,
     backgroundColor: Colors.light.surface,
     alignItems: 'center',
+    justifyContent: 'center',
     gap: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.04,
+    shadowRadius: 8,
+    elevation: 2,
   },
-  activeDayCard: { backgroundColor: Colors.light.primary },
-  dayName: { fontSize: 13, fontWeight: '600', color: Colors.light.text },
-  activeDayName: { color: '#FFF' },
-  dayDate: { fontSize: 11, color: Colors.light.textMuted },
-  activeDayDate: { color: 'rgba(255,255,255,0.8)' },
+  activeDayCard: { backgroundColor: Colors.light.primary, elevation: 4 },
+  dayText: { fontSize: 12, fontWeight: '500', color: Colors.light.textMuted },
+  activeDayText: { color: 'rgba(255,255,255,0.8)' },
+  dateText: { fontSize: 18, fontWeight: '700', color: Colors.light.text },
+  activeDateText: { color: '#FFFFFF' },
   scrollContent: { padding: 20, paddingBottom: 100 },
   sectionHeader: {
     flexDirection: 'row',

--- a/frontend/app/week-planning.tsx
+++ b/frontend/app/week-planning.tsx
@@ -54,6 +54,7 @@ export default function WeekPlanningScreen() {
 
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
   const [swapItem, setSwapItem] = useState<ScheduleItemRead | null>(null);
+  const [leftoverSourceTitle, setLeftoverSourceTitle] = useState<string | null>(null);
 
   const { backendUser, loading: profileLoading } = useUserProfile();
   const { data: scheduleItems = [], isLoading } = useWeekScheduleQuery(weekStart);
@@ -111,6 +112,13 @@ export default function WeekPlanningScreen() {
   };
 
   const handleSwap = (item: ScheduleItemRead) => {
+    if (item.source_schedule_item_id != null) {
+      const sourceItem = scheduleItems.find((i) => i.id === item.source_schedule_item_id);
+      setLeftoverSourceTitle(sourceItem?.meal?.title ?? 'the source meal');
+      setSwapItem(item);
+      return;
+    }
+    setLeftoverSourceTitle(null);
     if (!item.alternatives || item.alternatives.length === 0) {
       Alert.alert('No Alternatives', 'No alternative meals available for this slot.');
       return;
@@ -252,7 +260,8 @@ export default function WeekPlanningScreen() {
                   )}
                 </View>
                 <View style={styles.itemActions}>
-                  {item.alternatives && item.alternatives.length > 0 && (
+                  {(item.source_schedule_item_id != null ||
+                    (item.alternatives && item.alternatives.length > 0)) && (
                     <TouchableOpacity
                       onPress={() => handleSwap(item)}
                       style={[
@@ -282,10 +291,14 @@ export default function WeekPlanningScreen() {
 
       <AlternativesModal
         visible={swapItem !== null}
-        onClose={() => setSwapItem(null)}
+        onClose={() => {
+          setSwapItem(null);
+          setLeftoverSourceTitle(null);
+        }}
         currentMealTitle={swapItem?.meal?.title ?? null}
         alternatives={(swapItem?.alternatives ?? []) as MealRead[]}
         onSelect={handleSelectAlternative}
+        leftoverSourceTitle={leftoverSourceTitle}
       />
     </SafeAreaView>
   );

--- a/frontend/components/AlternativesModal.tsx
+++ b/frontend/components/AlternativesModal.tsx
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
   current: { fontSize: 13, color: Colors.light.textMuted, marginBottom: 8 },
   empty: { fontSize: 14, color: Colors.light.textMuted, textAlign: 'center', marginTop: 20 },
   option: {
-    backgroundColor: Colors.light.surface,
+    backgroundColor: Colors.light.background,
     borderRadius: Layout.cardRadius,
     padding: 16,
     gap: 4,
@@ -112,7 +112,7 @@ const styles = StyleSheet.create({
   optionTitle: { fontSize: 16, fontWeight: '600', color: Colors.light.text },
   optionMacros: { fontSize: 13, color: Colors.light.textMuted },
   noticeBox: {
-    backgroundColor: Colors.light.surface,
+    backgroundColor: Colors.light.background,
     borderRadius: Layout.cardRadius,
     padding: 16,
     gap: 6,

--- a/frontend/components/AlternativesModal.tsx
+++ b/frontend/components/AlternativesModal.tsx
@@ -2,7 +2,7 @@ import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from '@g
 import { Colors, Layout } from '@/constants/theme';
 import type { MealRead } from '@/api/types.gen';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 type AlternativesModalProps = {
   visible: boolean;
@@ -10,6 +10,8 @@ type AlternativesModalProps = {
   currentMealTitle: string | null;
   alternatives: MealRead[];
   onSelect: (mealId: number) => void;
+  /** If set, the item being inspected is a leftover of this source's meal title. */
+  leftoverSourceTitle?: string | null;
 };
 
 export function AlternativesModal({
@@ -18,9 +20,11 @@ export function AlternativesModal({
   currentMealTitle,
   alternatives,
   onSelect,
+  leftoverSourceTitle,
 }: AlternativesModalProps) {
   const bottomSheetRef = useRef<BottomSheetModal>(null);
-  const snapPoints = useMemo(() => ['80%'], []);
+  const snapPoints = useMemo(() => ['60%'], []);
+  const isLeftover = leftoverSourceTitle != null;
 
   useEffect(() => {
     if (visible) {
@@ -56,24 +60,40 @@ export function AlternativesModal({
     >
       <BottomSheetScrollView contentContainerStyle={styles.container}>
         <Text style={styles.title}>Swap Meal</Text>
-        {currentMealTitle && <Text style={styles.current}>Current: {currentMealTitle}</Text>}
-        {alternatives.length === 0 ? (
-          <Text style={styles.empty}>No alternatives available</Text>
+        {isLeftover ? (
+          <View style={styles.noticeBox}>
+            <Text style={styles.noticeTitle}>
+              This is a leftover of &quot;{leftoverSourceTitle}&quot;
+            </Text>
+            <Text style={styles.noticeBody}>
+              Leftovers follow their source meal. To change what you&apos;re eating, open the
+              source meal and swap or edit it there.
+            </Text>
+          </View>
         ) : (
-          alternatives.map((meal) => (
-            <TouchableOpacity
-              key={meal.id}
-              style={styles.option}
-              onPress={() => handleSelect(meal)}
-              activeOpacity={0.7}
-            >
-              <Text style={styles.optionTitle}>{meal.title}</Text>
-              <Text style={styles.optionMacros}>
-                {meal.calories} cal · {meal.protein}g protein · {meal.carbohydrates}g carbs ·{' '}
-                {meal.fat}g fat
-              </Text>
-            </TouchableOpacity>
-          ))
+          <>
+            {currentMealTitle && (
+              <Text style={styles.current}>Current: {currentMealTitle}</Text>
+            )}
+            {alternatives.length === 0 ? (
+              <Text style={styles.empty}>No alternatives available</Text>
+            ) : (
+              alternatives.map((meal) => (
+                <TouchableOpacity
+                  key={meal.id}
+                  style={styles.option}
+                  onPress={() => handleSelect(meal)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.optionTitle}>{meal.title}</Text>
+                  <Text style={styles.optionMacros}>
+                    {meal.calories} cal · {meal.protein}g protein · {meal.carbohydrates}g carbs ·{' '}
+                    {meal.fat}g fat
+                  </Text>
+                </TouchableOpacity>
+              ))
+            )}
+          </>
         )}
       </BottomSheetScrollView>
     </BottomSheetModal>
@@ -93,4 +113,12 @@ const styles = StyleSheet.create({
   },
   optionTitle: { fontSize: 16, fontWeight: '600', color: Colors.light.text },
   optionMacros: { fontSize: 13, color: Colors.light.textMuted },
+  noticeBox: {
+    backgroundColor: Colors.light.surface,
+    borderRadius: Layout.cardRadius,
+    padding: 16,
+    gap: 6,
+  },
+  noticeTitle: { fontSize: 15, fontWeight: '600', color: Colors.light.text },
+  noticeBody: { fontSize: 13, color: Colors.light.textMuted, lineHeight: 18 },
 });

--- a/frontend/components/AlternativesModal.tsx
+++ b/frontend/components/AlternativesModal.tsx
@@ -66,15 +66,13 @@ export function AlternativesModal({
               This is a leftover of &quot;{leftoverSourceTitle}&quot;
             </Text>
             <Text style={styles.noticeBody}>
-              Leftovers follow their source meal. To change what you&apos;re eating, open the
-              source meal and swap or edit it there.
+              Leftovers follow their source meal. To change what you&apos;re eating, open the source
+              meal and swap or edit it there.
             </Text>
           </View>
         ) : (
           <>
-            {currentMealTitle && (
-              <Text style={styles.current}>Current: {currentMealTitle}</Text>
-            )}
+            {currentMealTitle && <Text style={styles.current}>Current: {currentMealTitle}</Text>}
             {alternatives.length === 0 ? (
               <Text style={styles.empty}>No alternatives available</Text>
             ) : (

--- a/frontend/components/DurationPickerInput.tsx
+++ b/frontend/components/DurationPickerInput.tsx
@@ -1,0 +1,214 @@
+import { BottomSheetBackdrop, BottomSheetModal } from '@gorhom/bottom-sheet';
+import { Colors } from '@/constants/theme';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface DurationPickerInputProps {
+  label: string;
+  /** Duration string like "30 min", "1 hr 15 min", etc. */
+  value: string;
+  onChange: (v: string) => void;
+}
+
+/** Parse "30 min", "1 hr 15 min", "45", etc. into total minutes. */
+function parseDuration(value: string): number {
+  if (!value) return 30;
+  const hrMatch = value.match(/(\d+)\s*hr/i);
+  const minMatch = value.match(/(\d+)\s*min/i);
+  const hours = hrMatch ? parseInt(hrMatch[1], 10) : 0;
+  const mins = minMatch ? parseInt(minMatch[1], 10) : 0;
+  if (hours || mins) return hours * 60 + mins;
+  const raw = parseInt(value, 10);
+  return isNaN(raw) ? 30 : raw;
+}
+
+/** Convert total minutes to display string. */
+function formatDuration(totalMinutes: number): string {
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  if (h > 0 && m > 0) return `${h} hr ${m} min`;
+  if (h > 0) return `${h} hr`;
+  return `${m} min`;
+}
+
+/**
+ * For countdown mode, the DateTimePicker value represents duration.
+ * We create a Date at local midnight + duration to avoid timezone issues.
+ */
+function durationToDate(mins: number): Date {
+  const d = new Date();
+  d.setHours(Math.floor(mins / 60), mins % 60, 0, 0);
+  return d;
+}
+
+/** Extract duration minutes from a Date, relative to local midnight. */
+function dateToMinutes(date: Date): number {
+  return date.getHours() * 60 + date.getMinutes();
+}
+
+export function DurationPickerInput({ label, value, onChange }: DurationPickerInputProps) {
+  const totalMinutes = parseDuration(value);
+  const [tempMinutes, setTempMinutes] = useState(totalMinutes);
+
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const snapPoints = useMemo(() => ['45%'], []);
+
+  const open = () => {
+    setTempMinutes(parseDuration(value));
+    bottomSheetRef.current?.present();
+  };
+
+  const confirm = () => {
+    bottomSheetRef.current?.dismiss();
+    onChange(formatDuration(Math.max(5, tempMinutes)));
+  };
+
+  const cancel = () => bottomSheetRef.current?.dismiss();
+
+  const handleCountdownChange = (_event: DateTimePickerEvent, date?: Date) => {
+    if (date) {
+      setTempMinutes(dateToMinutes(date));
+    }
+  };
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
+
+  return (
+    <View>
+      <Text style={styles.label}>{label}</Text>
+      <TouchableOpacity style={styles.input} onPress={open} activeOpacity={0.7}>
+        <Text style={styles.inputText}>{formatDuration(totalMinutes)}</Text>
+      </TouchableOpacity>
+
+      <BottomSheetModal
+        ref={bottomSheetRef}
+        snapPoints={snapPoints}
+        enableDynamicSizing={false}
+        backdropComponent={renderBackdrop}
+      >
+        <View style={styles.pickerHeader}>
+          <TouchableOpacity onPress={cancel}>
+            <Text style={styles.pickerHeaderCancel}>Cancel</Text>
+          </TouchableOpacity>
+          <Text style={styles.pickerTitle}>Duration</Text>
+          <TouchableOpacity onPress={confirm}>
+            <Text style={styles.pickerHeaderDone}>Done</Text>
+          </TouchableOpacity>
+        </View>
+
+        {Platform.OS === 'ios' ? (
+          <DateTimePicker
+            value={durationToDate(tempMinutes)}
+            mode="countdown"
+            display="spinner"
+            textColor="black"
+            themeVariant="light"
+            minuteInterval={5}
+            onChange={handleCountdownChange}
+          />
+        ) : (
+          <View style={styles.androidOptions}>
+            {[15, 20, 30, 45, 60, 90, 120].map((m) => (
+              <TouchableOpacity
+                key={m}
+                style={[styles.androidChip, tempMinutes === m && styles.androidChipActive]}
+                onPress={() => setTempMinutes(m)}
+              >
+                <Text
+                  style={[
+                    styles.androidChipText,
+                    tempMinutes === m && styles.androidChipTextActive,
+                  ]}
+                >
+                  {formatDuration(m)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+      </BottomSheetModal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.light.text,
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: Colors.light.background,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  inputText: {
+    fontSize: 16,
+    color: Colors.light.text,
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  pickerTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.text,
+  },
+  pickerHeaderCancel: {
+    fontSize: 16,
+    color: Colors.light.textMuted,
+  },
+  pickerHeaderDone: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: Colors.light.primary,
+  },
+  androidOptions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  androidChip: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: Colors.light.background,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  androidChipActive: {
+    backgroundColor: Colors.light.primary,
+    borderColor: Colors.light.primary,
+  },
+  androidChipText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.light.textMuted,
+  },
+  androidChipTextActive: {
+    color: '#FFFFFF',
+  },
+});

--- a/frontend/components/EditItemModal.tsx
+++ b/frontend/components/EditItemModal.tsx
@@ -54,7 +54,6 @@ export function EditItemModal({
   const [fat, setFat] = useState(item?.fat?.toString() || '');
   const [workoutType, setWorkoutType] = useState(item?.workoutType || '');
   const [caloriesBurned, setCaloriesBurned] = useState('');
-  const [muscleGain, setMuscleGain] = useState('');
   const [targetHours, setTargetHours] = useState(item?.targetHours?.toString() || '8');
   const [touched, setTouched] = useState(false);
 
@@ -73,7 +72,7 @@ export function EditItemModal({
       if (isNaN(h) || h < 1 || h > 24) e.targetHours = 'Must be 1–24';
     }
     return e;
-  }, [title, calories, protein, carbs, fat, targetHours, currentType]);
+  }, [title, targetHours, currentType]);
 
   const isValid = Object.keys(errors).length === 0;
 
@@ -88,7 +87,6 @@ export function EditItemModal({
       setFat(item?.fat?.toString() || '');
       setWorkoutType(item?.workoutType || '');
       setCaloriesBurned(item?.type === 'workout' ? item?.calories?.toString() || '' : '');
-      setMuscleGain('');
       setTargetHours(item?.targetHours?.toString() || '8');
       setTouched(false);
       bottomSheetRef.current?.present();
@@ -259,17 +257,6 @@ export function EditItemModal({
                   value={caloriesBurned}
                   onChangeText={setCaloriesBurned}
                   placeholder="300"
-                  keyboardType="numeric"
-                  placeholderTextColor={Colors.light.textMuted}
-                />
-              </View>
-              <View style={[styles.field, styles.macroField]}>
-                <Text style={styles.macroLabel}>Muscle Gain (g)</Text>
-                <TextInput
-                  style={styles.input}
-                  value={muscleGain}
-                  onChangeText={setMuscleGain}
-                  placeholder="20"
                   keyboardType="numeric"
                   placeholderTextColor={Colors.light.textMuted}
                 />

--- a/frontend/components/EditItemModal.tsx
+++ b/frontend/components/EditItemModal.tsx
@@ -281,7 +281,16 @@ export function EditItemModal({
         )}
 
         <View style={styles.field}>
-          <DurationPickerInput label="Duration" value={duration} onChange={setDuration} />
+          {currentType === 'meal' ? (
+            <>
+              <Text style={styles.label}>Duration</Text>
+              <View style={[styles.input, styles.readonly]}>
+                <Text style={styles.readonlyText}>{duration}</Text>
+              </View>
+            </>
+          ) : (
+            <DurationPickerInput label="Duration" value={duration} onChange={setDuration} />
+          )}
         </View>
       </BottomSheetScrollView>
 

--- a/frontend/components/EditItemModal.tsx
+++ b/frontend/components/EditItemModal.tsx
@@ -1,7 +1,9 @@
 import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { Colors } from '@/constants/theme';
 import type { ItemType, WeeklyScheduleItem } from '@/types/schedule';
+import { DurationPickerInput } from '@/components/DurationPickerInput';
 import { TimePickerInput } from '@/components/TimePickerInput';
+import { Dumbbell, Moon, UtensilsCrossed } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
@@ -14,6 +16,27 @@ type EditItemModalProps = {
   itemType?: ItemType;
 };
 
+const TYPE_CONFIG = {
+  meal: {
+    label: 'Meal',
+    subtitle: 'Nutrition & schedule',
+    color: Colors.light.secondary,
+    Icon: UtensilsCrossed,
+  },
+  workout: {
+    label: 'Workout',
+    subtitle: 'Exercise details',
+    color: Colors.light.primary,
+    Icon: Dumbbell,
+  },
+  sleep: {
+    label: 'Sleep',
+    subtitle: 'Rest & recovery',
+    color: Colors.light.charts.carbs,
+    Icon: Moon,
+  },
+} as const;
+
 export function EditItemModal({
   visible,
   onClose,
@@ -24,26 +47,50 @@ export function EditItemModal({
 }: EditItemModalProps) {
   const [time, setTime] = useState(item?.time || '7:00 AM');
   const [title, setTitle] = useState(item?.title || '');
-  const [subtitle, setSubtitle] = useState(item?.subtitle || '');
   const [duration, setDuration] = useState(item?.duration || '30 min');
   const [calories, setCalories] = useState(item?.calories?.toString() || '');
+  const [protein, setProtein] = useState(item?.protein?.toString() || '');
+  const [carbs, setCarbs] = useState(item?.carbs?.toString() || '');
+  const [fat, setFat] = useState(item?.fat?.toString() || '');
   const [workoutType, setWorkoutType] = useState(item?.workoutType || '');
+  const [caloriesBurned, setCaloriesBurned] = useState('');
+  const [muscleGain, setMuscleGain] = useState('');
   const [targetHours, setTargetHours] = useState(item?.targetHours?.toString() || '8');
+  const [touched, setTouched] = useState(false);
 
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ['90%'], []);
 
   const currentType = item?.type || itemType;
+  const config = TYPE_CONFIG[currentType];
+
+  const errors = useMemo(() => {
+    const e: Record<string, string> = {};
+    if (!title.trim()) e.title = 'Title is required';
+    // Macros are read-only on meal; no validation needed.
+    if (currentType === 'sleep' && targetHours) {
+      const h = parseFloat(targetHours);
+      if (isNaN(h) || h < 1 || h > 24) e.targetHours = 'Must be 1–24';
+    }
+    return e;
+  }, [title, calories, protein, carbs, fat, targetHours, currentType]);
+
+  const isValid = Object.keys(errors).length === 0;
 
   useEffect(() => {
     if (visible) {
       setTime(item?.time || '7:00 AM');
       setTitle(item?.title || '');
-      setSubtitle(item?.subtitle || '');
       setDuration(item?.duration || '30 min');
       setCalories(item?.calories?.toString() || '');
+      setProtein(item?.protein?.toString() || '');
+      setCarbs(item?.carbs?.toString() || '');
+      setFat(item?.fat?.toString() || '');
       setWorkoutType(item?.workoutType || '');
+      setCaloriesBurned(item?.type === 'workout' ? item?.calories?.toString() || '' : '');
+      setMuscleGain('');
       setTargetHours(item?.targetHours?.toString() || '8');
+      setTouched(false);
       bottomSheetRef.current?.present();
     } else {
       bottomSheetRef.current?.dismiss();
@@ -51,35 +98,35 @@ export function EditItemModal({
   }, [visible, item]);
 
   const handleSave = () => {
-    const baseItem = {
+    setTouched(true);
+    if (!isValid) return;
+
+    const cal = calories ? parseInt(calories) : undefined;
+    const pro = protein ? parseInt(protein) : undefined;
+    const carb = carbs ? parseInt(carbs) : undefined;
+    const f = fat ? parseInt(fat) : undefined;
+
+    const baseItem: WeeklyScheduleItem = {
       id: item?.id || `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       time,
       title,
-      subtitle: subtitle || undefined,
       duration,
       type: currentType,
     };
 
-    let updatedItem: WeeklyScheduleItem = baseItem;
-
     if (currentType === 'meal') {
-      updatedItem = {
-        ...baseItem,
-        calories: calories ? parseInt(calories) : undefined,
-      };
+      baseItem.calories = cal;
+      baseItem.protein = pro;
+      baseItem.carbs = carb;
+      baseItem.fat = f;
     } else if (currentType === 'workout') {
-      updatedItem = {
-        ...baseItem,
-        workoutType: workoutType || title,
-      };
+      baseItem.workoutType = workoutType || title;
+      baseItem.calories = caloriesBurned ? parseInt(caloriesBurned) : undefined;
     } else if (currentType === 'sleep') {
-      updatedItem = {
-        ...baseItem,
-        targetHours: targetHours ? parseFloat(targetHours) : 8,
-      };
+      baseItem.targetHours = targetHours ? parseFloat(targetHours) : 8;
     }
 
-    onSave(updatedItem);
+    onSave(baseItem);
     onClose();
   };
 
@@ -95,6 +142,16 @@ export function EditItemModal({
     []
   );
 
+  const renderError = (field: string) => {
+    if (!touched || !errors[field]) return null;
+    return <Text style={styles.errorText}>{errors[field]}</Text>;
+  };
+
+  const inputStyle = (field: string) => [
+    styles.input,
+    touched && errors[field] && styles.inputError,
+  ];
+
   return (
     <BottomSheetModal
       ref={bottomSheetRef}
@@ -106,15 +163,20 @@ export function EditItemModal({
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustResize"
     >
+      <View style={[styles.headerStrip, { backgroundColor: config.color }]} />
+
       <View style={styles.header}>
-        <Text style={styles.headerTitle}>{mode === 'edit' ? 'Edit Item' : 'Add Item'}</Text>
-        <Text style={styles.headerSubtitle}>
-          {currentType === 'meal'
-            ? 'Meal details'
-            : currentType === 'workout'
-              ? 'Workout details'
-              : 'Sleep details'}
-        </Text>
+        <View style={styles.headerLeft}>
+          <View style={[styles.iconCircle, { backgroundColor: config.color + '18' }]}>
+            <config.Icon size={20} color={config.color} />
+          </View>
+          <View>
+            <Text style={styles.headerTitle}>
+              {mode === 'edit' ? 'Edit' : 'Add'} {config.label}
+            </Text>
+            <Text style={styles.headerSubtitle}>{config.subtitle}</Text>
+          </View>
+        </View>
       </View>
 
       <BottomSheetScrollView contentContainerStyle={styles.form}>
@@ -125,7 +187,7 @@ export function EditItemModal({
         <View style={styles.field}>
           <Text style={styles.label}>Title</Text>
           <TextInput
-            style={styles.input}
+            style={inputStyle('title')}
             value={title}
             onChangeText={setTitle}
             placeholder={
@@ -137,71 +199,102 @@ export function EditItemModal({
             }
             placeholderTextColor={Colors.light.textMuted}
           />
+          {renderError('title')}
         </View>
 
         {currentType === 'meal' && (
           <>
-            <View style={styles.field}>
-              <Text style={styles.label}>Description</Text>
-              <TextInput
-                style={styles.input}
-                value={subtitle}
-                onChangeText={setSubtitle}
-                placeholder="e.g., with berries and granola"
-                placeholderTextColor={Colors.light.textMuted}
-              />
+            <Text style={styles.sectionLabel}>Nutrition</Text>
+            <Text style={[styles.macroLabel, { marginBottom: 8 }]}>
+              Set by the recipe — cannot be edited here.
+            </Text>
+            <View style={styles.macroRow}>
+              <View style={[styles.field, styles.macroField]}>
+                <Text style={styles.macroLabel}>Calories</Text>
+                <View style={[styles.input, styles.readonly]}>
+                  <Text style={styles.readonlyText}>{calories || '—'}</Text>
+                </View>
+              </View>
+              <View style={[styles.field, styles.macroField]}>
+                <Text style={styles.macroLabel}>Protein (g)</Text>
+                <View style={[styles.input, styles.readonly]}>
+                  <Text style={styles.readonlyText}>{protein || '—'}</Text>
+                </View>
+              </View>
             </View>
-
-            <View style={styles.field}>
-              <Text style={styles.label}>Calories</Text>
-              <TextInput
-                style={styles.input}
-                value={calories}
-                onChangeText={setCalories}
-                placeholder="e.g., 380"
-                keyboardType="numeric"
-                placeholderTextColor={Colors.light.textMuted}
-              />
+            <View style={styles.macroRow}>
+              <View style={[styles.field, styles.macroField]}>
+                <Text style={styles.macroLabel}>Carbs (g)</Text>
+                <View style={[styles.input, styles.readonly]}>
+                  <Text style={styles.readonlyText}>{carbs || '—'}</Text>
+                </View>
+              </View>
+              <View style={[styles.field, styles.macroField]}>
+                <Text style={styles.macroLabel}>Fat (g)</Text>
+                <View style={[styles.input, styles.readonly]}>
+                  <Text style={styles.readonlyText}>{fat || '—'}</Text>
+                </View>
+              </View>
             </View>
           </>
         )}
 
         {currentType === 'workout' && (
-          <View style={styles.field}>
-            <Text style={styles.label}>Workout Type</Text>
-            <TextInput
-              style={styles.input}
-              value={workoutType}
-              onChangeText={setWorkoutType}
-              placeholder="e.g., HIIT, Strength, Yoga"
-              placeholderTextColor={Colors.light.textMuted}
-            />
-          </View>
+          <>
+            <View style={styles.field}>
+              <Text style={styles.label}>Workout Type</Text>
+              <TextInput
+                style={styles.input}
+                value={workoutType}
+                onChangeText={setWorkoutType}
+                placeholder="e.g., HIIT, Strength, Yoga"
+                placeholderTextColor={Colors.light.textMuted}
+              />
+            </View>
+            <View style={styles.macroRow}>
+              <View style={[styles.field, styles.macroField]}>
+                <Text style={styles.macroLabel}>Calories Burned</Text>
+                <TextInput
+                  style={styles.input}
+                  value={caloriesBurned}
+                  onChangeText={setCaloriesBurned}
+                  placeholder="300"
+                  keyboardType="numeric"
+                  placeholderTextColor={Colors.light.textMuted}
+                />
+              </View>
+              <View style={[styles.field, styles.macroField]}>
+                <Text style={styles.macroLabel}>Muscle Gain (g)</Text>
+                <TextInput
+                  style={styles.input}
+                  value={muscleGain}
+                  onChangeText={setMuscleGain}
+                  placeholder="20"
+                  keyboardType="numeric"
+                  placeholderTextColor={Colors.light.textMuted}
+                />
+              </View>
+            </View>
+          </>
         )}
 
         {currentType === 'sleep' && (
           <View style={styles.field}>
             <Text style={styles.label}>Target Hours</Text>
             <TextInput
-              style={styles.input}
+              style={inputStyle('targetHours')}
               value={targetHours}
               onChangeText={setTargetHours}
               placeholder="e.g., 8"
               keyboardType="decimal-pad"
               placeholderTextColor={Colors.light.textMuted}
             />
+            {renderError('targetHours')}
           </View>
         )}
 
         <View style={styles.field}>
-          <Text style={styles.label}>Duration</Text>
-          <TextInput
-            style={styles.input}
-            value={duration}
-            onChangeText={setDuration}
-            placeholder="e.g., 30 min"
-            placeholderTextColor={Colors.light.textMuted}
-          />
+          <DurationPickerInput label="Duration" value={duration} onChange={setDuration} />
         </View>
       </BottomSheetScrollView>
 
@@ -209,7 +302,10 @@ export function EditItemModal({
         <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
           <Text style={styles.cancelButtonText}>Cancel</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+        <TouchableOpacity
+          style={[styles.saveButton, touched && !isValid && styles.saveButtonDisabled]}
+          onPress={handleSave}
+        >
           <Text style={styles.saveButtonText}>Save</Text>
         </TouchableOpacity>
       </View>
@@ -218,10 +314,28 @@ export function EditItemModal({
 }
 
 const styles = StyleSheet.create({
+  headerStrip: {
+    height: 4,
+  },
   header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     padding: 20,
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   headerTitle: {
     fontSize: 20,
@@ -229,9 +343,9 @@ const styles = StyleSheet.create({
     color: Colors.light.text,
   },
   headerSubtitle: {
-    fontSize: 14,
+    fontSize: 13,
     color: Colors.light.textMuted,
-    marginTop: 2,
+    marginTop: 1,
   },
   form: {
     padding: 20,
@@ -245,6 +359,19 @@ const styles = StyleSheet.create({
     color: Colors.light.text,
     marginBottom: 8,
   },
+  sectionLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: Colors.light.text,
+    marginBottom: 12,
+    marginTop: 4,
+  },
+  macroLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.light.textMuted,
+    marginBottom: 6,
+  },
   input: {
     backgroundColor: Colors.light.surface,
     borderRadius: 12,
@@ -253,6 +380,21 @@ const styles = StyleSheet.create({
     color: Colors.light.text,
     borderWidth: 1,
     borderColor: '#E5E7EB',
+  },
+  inputError: {
+    borderColor: Colors.light.error,
+  },
+  errorText: {
+    color: Colors.light.error,
+    fontSize: 12,
+    marginTop: 4,
+  },
+  macroRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  macroField: {
+    flex: 1,
   },
   actions: {
     flexDirection: 'row',
@@ -280,9 +422,22 @@ const styles = StyleSheet.create({
     padding: 16,
     alignItems: 'center',
   },
+  saveButtonDisabled: {
+    opacity: 0.5,
+  },
   saveButtonText: {
     fontSize: 16,
     fontWeight: '600',
     color: '#FFFFFF',
+  },
+  readonly: {
+    backgroundColor: Colors.light.background,
+    justifyContent: 'center',
+    minHeight: 46,
+  },
+  readonlyText: {
+    fontSize: 15,
+    color: Colors.light.textMuted,
+    fontWeight: '600',
   },
 });

--- a/frontend/components/MealDetailModal.tsx
+++ b/frontend/components/MealDetailModal.tsx
@@ -20,6 +20,7 @@ interface MealDetailModalProps {
   meal: MealData | null;
   onModify?: (meal: MealData) => void;
   onRemove?: (meal: MealData) => void;
+  readOnly?: boolean;
 }
 
 export const MealDetailModal = ({
@@ -28,6 +29,7 @@ export const MealDetailModal = ({
   meal,
   onModify,
   onRemove,
+  readOnly = false,
 }: MealDetailModalProps) => {
   const bottomSheetRef = useRef<BottomSheetModal>(null);
   const snapPoints = useMemo(() => ['85%'], []);
@@ -135,28 +137,30 @@ export const MealDetailModal = ({
           </TouchableOpacity>
         )}
 
-        <View style={styles.actionsRow}>
-          <TouchableOpacity
-            style={[styles.actionButton, { backgroundColor: Colors.light.background, flex: 1 }]}
-            onPress={() => {
-              onModify?.(meal);
-              onClose();
-            }}
-          >
-            <Edit size={20} color={Colors.light.text} />
-            <Text style={[styles.actionButtonText, { color: Colors.light.text }]}>Modify</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.actionButton, { backgroundColor: `${Colors.light.error}15` }]}
-            onPress={() => {
-              onRemove?.(meal);
-              onClose();
-            }}
-          >
-            <Trash2 size={20} color={Colors.light.error} />
-            <Text style={[styles.actionButtonText, { color: Colors.light.error }]}>Remove</Text>
-          </TouchableOpacity>
-        </View>
+        {!readOnly && (
+          <View style={styles.actionsRow}>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: Colors.light.background, flex: 1 }]}
+              onPress={() => {
+                onModify?.(meal);
+                onClose();
+              }}
+            >
+              <Edit size={20} color={Colors.light.text} />
+              <Text style={[styles.actionButtonText, { color: Colors.light.text }]}>Modify</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, { backgroundColor: `${Colors.light.error}15` }]}
+              onPress={() => {
+                onRemove?.(meal);
+                onClose();
+              }}
+            >
+              <Trash2 size={20} color={Colors.light.error} />
+              <Text style={[styles.actionButtonText, { color: Colors.light.error }]}>Remove</Text>
+            </TouchableOpacity>
+          </View>
+        )}
       </BottomSheetScrollView>
     </BottomSheetModal>
   );

--- a/frontend/components/MealDetailModal.tsx
+++ b/frontend/components/MealDetailModal.tsx
@@ -3,21 +3,14 @@ import { Colors } from '@/constants/theme';
 import { ArrowRight, Edit, Trash2 } from 'lucide-react-native';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-
-interface RecipeData {
-  title?: string;
-  nutrients?: { calories?: number; protein?: number; carbohydrates?: number; fat?: number };
-  ingredients?: string[];
-  source_url?: string;
-  preparation_time_minutes?: number;
-}
+import type { MealRead } from '@/api/types.gen';
 
 interface MealData {
   time: string;
   title?: string;
   subtitle?: string;
   type: string;
-  recipe?: RecipeData;
+  meal?: MealRead | null;
   [key: string]: unknown;
 }
 
@@ -61,12 +54,16 @@ export const MealDetailModal = ({
 
   if (!meal) return null;
 
-  const recipe = meal.recipe;
-  const title = recipe?.title || meal.title || 'Meal';
-  const nutrients = recipe?.nutrients;
-  const ingredients = recipe?.ingredients || [];
-  const sourceUrl = recipe?.source_url;
-  const prepTime = recipe?.preparation_time_minutes;
+  const m = meal.meal;
+  const title = m?.title || meal.title || 'Meal';
+  const calories = m?.calories;
+  const protein = m?.protein;
+  const carbs = m?.carbohydrates;
+  const fat = m?.fat;
+  const ingredients = m?.ingredients ?? [];
+  const sourceUrl = m?.source_url ?? null;
+  const prepTime = m?.prep_time_minutes ?? null;
+  const showMacros = calories != null || protein != null || carbs != null || fat != null;
 
   return (
     <BottomSheetModal
@@ -83,29 +80,29 @@ export const MealDetailModal = ({
           {prepTime ? ` · ${prepTime} min prep` : ''}
         </Text>
 
-        {nutrients && (
+        {showMacros && (
           <View style={styles.sectionBox}>
             <Text style={styles.sectionHeader}>MACRONUTRIENTS</Text>
             <View style={styles.macrosGrid}>
               <View style={styles.macroItem}>
-                <Text style={styles.macroValue}>{nutrients.calories}</Text>
+                <Text style={styles.macroValue}>{calories ?? '—'}</Text>
                 <Text style={styles.macroLabel}>Calories</Text>
               </View>
               <View style={styles.macroItem}>
                 <Text style={[styles.macroValue, { color: Colors.light.primary }]}>
-                  {nutrients.protein}g
+                  {protein != null ? `${protein}g` : '—'}
                 </Text>
                 <Text style={styles.macroLabel}>Protein</Text>
               </View>
               <View style={styles.macroItem}>
                 <Text style={[styles.macroValue, { color: Colors.light.charts.carbs }]}>
-                  {nutrients.carbohydrates}g
+                  {carbs != null ? `${carbs}g` : '—'}
                 </Text>
                 <Text style={styles.macroLabel}>Carbs</Text>
               </View>
               <View style={styles.macroItem}>
                 <Text style={[styles.macroValue, { color: Colors.light.charts.fats }]}>
-                  {nutrients.fat}g
+                  {fat != null ? `${fat}g` : '—'}
                 </Text>
                 <Text style={styles.macroLabel}>Fats</Text>
               </View>

--- a/frontend/components/MissedItemModal.tsx
+++ b/frontend/components/MissedItemModal.tsx
@@ -1,15 +1,7 @@
-import { BottomSheetBackdrop, BottomSheetModal } from '@gorhom/bottom-sheet';
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { Colors } from '@/constants/theme';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-  KeyboardAvoidingView,
-  Platform,
-} from 'react-native';
+import { StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 type Props = {
   visible: boolean;
@@ -79,10 +71,7 @@ export function MissedItemModal({ visible, itemTitle, itemType, onSave, onClose 
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
     >
-      <KeyboardAvoidingView
-        style={styles.container}
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      >
+      <BottomSheetScrollView contentContainerStyle={styles.body}>
         <View style={styles.header}>
           <Text style={styles.title}>Missed {typeLabel}?</Text>
           <Text style={styles.subtitle} numberOfLines={1}>
@@ -114,25 +103,23 @@ export function MissedItemModal({ visible, itemTitle, itemType, onSave, onClose 
             textAlignVertical="top"
           />
         )}
+      </BottomSheetScrollView>
 
-        <View style={styles.actions}>
-          <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
-            <Text style={styles.cancelText}>Cancel</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
-            <Text style={styles.saveText}>Save</Text>
-          </TouchableOpacity>
-        </View>
-      </KeyboardAvoidingView>
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
+          <Text style={styles.cancelText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+          <Text style={styles.saveText}>Save</Text>
+        </TouchableOpacity>
+      </View>
     </BottomSheetModal>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  body: {
     paddingHorizontal: 20,
-    paddingBottom: 20,
   },
   header: {
     paddingVertical: 16,
@@ -192,7 +179,9 @@ const styles = StyleSheet.create({
   actions: {
     flexDirection: 'row',
     gap: 12,
-    marginTop: 'auto',
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 40,
   },
   cancelButton: {
     flex: 1,

--- a/frontend/components/SwipeableScheduleItem.tsx
+++ b/frontend/components/SwipeableScheduleItem.tsx
@@ -1,7 +1,7 @@
 import { Colors } from '@/constants/theme';
 import { Check, X } from 'lucide-react-native';
 import React, { useRef } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Animated, StyleSheet, Text, View } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 
 type Props = {
@@ -13,20 +13,46 @@ type Props = {
   onConfirmMissed: () => void;
 };
 
-function LeftAction() {
+type Progress = Animated.AnimatedInterpolation<number>;
+
+function renderLeft(progress: Progress) {
+  const opacity = progress.interpolate({
+    inputRange: [0, 0.4, 1],
+    outputRange: [0, 0.7, 1],
+    extrapolate: 'clamp',
+  });
+  const scale = progress.interpolate({
+    inputRange: [0, 0.6, 1],
+    outputRange: [0.6, 0.95, 1],
+    extrapolate: 'clamp',
+  });
   return (
     <View style={styles.leftAction}>
-      <Check size={24} color="#FFF" strokeWidth={3} />
-      <Text style={styles.actionLabel}>Done</Text>
+      <Animated.View style={[styles.actionContent, { opacity, transform: [{ scale }] }]}>
+        <Check size={22} color="#FFF" strokeWidth={3} />
+        <Text style={styles.actionLabel}>Done</Text>
+      </Animated.View>
     </View>
   );
 }
 
-function RightAction() {
+function renderRight(progress: Progress) {
+  const opacity = progress.interpolate({
+    inputRange: [0, 0.4, 1],
+    outputRange: [0, 0.7, 1],
+    extrapolate: 'clamp',
+  });
+  const scale = progress.interpolate({
+    inputRange: [0, 0.6, 1],
+    outputRange: [0.6, 0.95, 1],
+    extrapolate: 'clamp',
+  });
   return (
     <View style={styles.rightAction}>
-      <X size={24} color="#FFF" strokeWidth={3} />
-      <Text style={styles.actionLabel}>Missed</Text>
+      <Animated.View style={[styles.actionContent, { opacity, transform: [{ scale }] }]}>
+        <X size={22} color="#FFF" strokeWidth={3} />
+        <Text style={styles.actionLabel}>Missed</Text>
+      </Animated.View>
     </View>
   );
 }
@@ -56,8 +82,15 @@ export function SwipeableScheduleItem({
   return (
     <Swipeable
       ref={swipeRef}
-      renderLeftActions={() => <LeftAction />}
-      renderRightActions={() => <RightAction />}
+      friction={2}
+      leftThreshold={48}
+      rightThreshold={48}
+      overshootLeft={false}
+      overshootRight={false}
+      containerStyle={styles.container}
+      childrenContainerStyle={styles.childrenContainer}
+      renderLeftActions={renderLeft}
+      renderRightActions={renderRight}
       onSwipeableOpen={handleOpen}
     >
       {children}
@@ -66,20 +99,30 @@ export function SwipeableScheduleItem({
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  childrenContainer: {
+    flex: 1,
+  },
   leftAction: {
     backgroundColor: Colors.light.success,
     justifyContent: 'center',
     alignItems: 'center',
-    width: 80,
-    borderRadius: 12,
-    gap: 4,
+    width: 88,
+    borderRadius: 16,
   },
   rightAction: {
     backgroundColor: Colors.light.error,
     justifyContent: 'center',
     alignItems: 'center',
-    width: 80,
-    borderRadius: 12,
+    width: 88,
+    borderRadius: 16,
+  },
+  actionContent: {
+    alignItems: 'center',
     gap: 4,
   },
   actionLabel: {

--- a/frontend/types/schedule.ts
+++ b/frontend/types/schedule.ts
@@ -7,11 +7,15 @@ export type WeeklyScheduleItem = {
   subtitle?: string;
   duration: string;
   type: ItemType;
-  calories?: number;
+  status?: 'completed' | 'current' | 'upcoming';
   workoutType?: string;
   targetHours?: number;
   alternatives?: WeeklyScheduleItem[];
   recipe?: Record<string, unknown>;
+  calories?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
 };
 
 export type DaySchedule = {

--- a/frontend/utils/date.ts
+++ b/frontend/utils/date.ts
@@ -1,0 +1,22 @@
+/**
+ * Format a Date as a local-timezone YYYY-MM-DD string.
+ *
+ * Unlike `d.toISOString().split('T')[0]` (which converts to UTC first),
+ * this uses the Date's local components — so a Monday 10 PM in PDT stays
+ * `2026-04-20`, not `2026-04-21` like the UTC conversion would yield.
+ */
+export function toLocalDateStr(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/**
+ * Return the Monday of the week containing `d` as a local YYYY-MM-DD string.
+ */
+export function mondayOf(d: Date): string {
+  const dow = d.getDay();
+  const diff = dow === 0 ? -6 : 1 - dow;
+  const monday = new Date(d);
+  monday.setDate(d.getDate() + diff);
+  return toLocalDateStr(monday);
+}


### PR DESCRIPTION
## Summary

Rebases the useful parts of #219 onto #231's cleaner meal-plan schema and fixes the core edit/tap/swap bugs that were blocking demo. #231 unifies meals into the existing schedule_items table via a Meal 1:1 and a ScheduleItemAlternative join table, which makes #219's parallel planned_events hierarchy redundant. Rather than reconciling two competing schemas, this branch builds on top of #231 and keeps only the independent UI polish from #219.

Frontend ports the type-colored EditItemModal with validation, the 2x2 macro grid, and DurationPickerInput from #219. Meal macros on #231 live on a shared Meal row across all slots that reference the same recipe, so EditItemModal renders them read-only with a "set by the recipe" note rather than letting edits silently mutate unrelated slots. handleEditSave now rebuilds an ISO date from the modal's time field and sends it alongside duration_minutes so time edits actually persist. MealDetailModal was expecting a nested recipe wrapper from the old plan_data shape; it now reads directly from MealRead, so tapping a meal shows the title, macros, ingredients, and source link. Home screen macro totals now include meals whose scheduled time has passed, not only is_completed ones, so Today's card actually updates during the day without requiring the user to manually mark each meal done.

Backend adds leftover cascades that were missing on #231. Deleting a cook-day meal now also deletes any downstream schedule_items that point back at it via source_schedule_item_id, instead of leaving an orphaned leftover with a SET NULL reference. Swapping a primary meal to one of its alternatives now propagates the new meal_id to those downstream leftovers too, so Tuesday's leftover-of-Monday follows Monday's swap. Both cascades have TDD tests in test_schedules.py (the tests are committed but weren't run against this dev DB to avoid the conftest's drop_all teardown against Neon).

Leftover rows are now labeled in the UI with a small pill on the schedule tab, and the swap modal short-circuits for leftovers with an inline explanation pointing the user back to the source meal, rather than letting them click Swap and get a silent 400 from the backend's alternatives check.

## Relationship to other work

Supersedes #219. Built on top of #231 (fix/refactor-db); when #231 merges to main this branch should be retargeted. Reuses the TimePickerInput already present on #231 and the useCreate/Update/Delete/CompleteScheduleItemMutation hooks in lib/queries/schedule.ts.

## Follow-ups not addressed here

The missed-meal modal's "what did you actually eat" textbox still doesn't persist — that needs a schema change and is worth a separate PR. The planning screen still lacks an add-custom/save affordance and its day selector doesn't match the schedule tab's compact cards. "Swipe to log" still has no discoverability hint. The backend conftest drops all tables on teardown against whatever DATABASE_URL points at, which truncates the dev DB on every pytest run — worth fixing with a host-check guard before anyone else runs tests locally.

## Issues

Closes #214